### PR TITLE
Masked arrays i.e. Handle frames of variable size (with known maximum)

### DIFF
--- a/tests/imagesources_test.py
+++ b/tests/imagesources_test.py
@@ -33,6 +33,8 @@ from PyQt4.QtCore import QRect
 from PyQt4.QtGui import QImage
 from PyQt4.QtGui import QColor
 
+import qimage2ndarray
+
 #volumina
 import volumina._testing
 from volumina.pixelpipeline.imagesources import GrayscaleImageSource, AlphaModulatedImageSource, RGBAImageSource, \
@@ -134,6 +136,55 @@ class GrayscaleImageSourceTest( ImageSourcesTestBase ):
         self.ims.setDirty((slice(34,37), slice(12,34)))
         self.ims.isDirty.disconnect( checkDirtyRect )
 
+class GrayscaleImageSourceTest2( ImageSourcesTestBase ):
+    def setUp( self ):
+        super( GrayscaleImageSourceTest2, self ).setUp()
+        self.raw = numpy.load(os.path.join(volumina._testing.__path__[0], 'lena.npy')).astype( numpy.uint32 )
+        self.raw = numpy.ma.masked_array(self.raw, numpy.zeros(self.raw.shape, dtype=bool), shrink=False)
+
+        self.raw[:10, :] = numpy.ma.masked
+        self.raw[-10:, :] = numpy.ma.masked
+        self.raw[:, :10] = numpy.ma.masked
+        self.raw[:, -10:] = numpy.ma.masked
+
+        self.ars = _ArraySource2d(self.raw)
+        self.ims = GrayscaleImageSource( self.ars, GrayscaleLayer( self.ars ))
+
+    def testRequest( self ):
+        imr = self.ims.request(QRect(0,0,512,512))
+        def check(result, codon):
+            self.assertEqual(codon, "unique")
+            self.assertTrue(type(result) == QImage)
+
+            result_array = qimage2ndarray.byte_view(result)
+
+            assert((result_array[:10, :, -1] == 255).all())
+            assert((result_array[-10:, :, -1] == 255).all())
+            assert((result_array[:, :10, -1] == 255).all())
+            assert((result_array[:, -10:, -1] == 255).all())
+
+        imr.notify(check, codon="unique")
+
+    def testSetDirty( self ):
+        def checkAllDirty( rect ):
+            self.assertTrue( rect.isEmpty() )
+
+        def checkDirtyRect( rect ):
+            self.assertEqual( rect.x(), 34 )
+            self.assertEqual( rect.y(), 12 )
+            self.assertEqual( rect.width(), 3 )
+            self.assertEqual( rect.height(), 22  )
+
+        # should mark everything dirty
+        self.ims.isDirty.connect( checkAllDirty )
+        self.ims.setDirty((slice(34,None), slice(12,34)))
+        self.ims.isDirty.disconnect( checkAllDirty )
+
+        # dirty subrect
+        self.ims.isDirty.connect( checkDirtyRect )
+        self.ims.setDirty((slice(34,37), slice(12,34)))
+        self.ims.isDirty.disconnect( checkDirtyRect )
+
 #*******************************************************************************
 # A l p h a M o d u l a t e d I m a g e S o u r c e T e s t
 #*******************************************************************************
@@ -150,6 +201,61 @@ class AlphaModulatedImageSourceTest( ImageSourcesTestBase ):
         def check(result, codon):
             self.assertEqual(codon, "unique")
             self.assertTrue(type(result) == QImage)
+
+        imr.notify(check, codon="unique")
+
+    def testSetDirty( self ):
+        def checkAllDirty( rect ):
+            self.assertTrue( rect.isEmpty() )
+
+        def checkDirtyRect( rect ):
+            self.assertEqual( rect.x(), 34 )
+            self.assertEqual( rect.y(), 12 )
+            self.assertEqual( rect.width(), 3 )
+            self.assertEqual( rect.height(), 22  )
+
+        # should mark everything dirty
+        self.ims.isDirty.connect( checkAllDirty )
+        self.ims.setDirty((slice(34,None), slice(12,34)))
+        self.ims.isDirty.disconnect( checkAllDirty )
+
+        # dirty subrect
+        self.ims.isDirty.connect( checkDirtyRect )
+        self.ims.setDirty((slice(34,37), slice(12,34)))
+        self.ims.isDirty.disconnect( checkDirtyRect )
+
+class AlphaModulatedImageSourceTest2( ImageSourcesTestBase ):
+    def setUp( self ):
+        super( AlphaModulatedImageSourceTest2, self ).setUp()
+        self.raw = numpy.load(os.path.join(volumina._testing.__path__[0], 'lena.npy')).astype( numpy.uint32 )
+
+        self.raw = numpy.ma.masked_array(self.raw, mask=numpy.zeros(self.raw.shape, dtype=bool), shrink=False)
+        self.raw[:1, :] = numpy.ma.masked
+        self.raw[-1:, :] = numpy.ma.masked
+        self.raw[:, :1] = numpy.ma.masked
+        self.raw[:, -1:] = numpy.ma.masked
+
+        self.ars = _ArraySource2d(self.raw)
+        self.ims = AlphaModulatedImageSource( self.ars, AlphaModulatedLayer( self.ars, QColor(1,2,3) ))
+
+    def testRequest( self ):
+        imr = self.ims.request(QRect(0,0,512,512))
+        def check(result, codon):
+            self.assertEqual(codon, "unique")
+            self.assertTrue(type(result) == QImage)
+
+
+            result_view = qimage2ndarray.byte_view(result)
+            if sys.byteorder == "little":
+                self.assertTrue((result_view[:1, :, 3] == 0).all())
+                self.assertTrue((result_view[-1:, :, 3] == 0).all())
+                self.assertTrue((result_view[:, :1, 3] == 0).all())
+                self.assertTrue((result_view[:, -1:, 3] == 0).all())
+            else:
+                self.assertTrue((result_view[:1, :, 0] == 0).all())
+                self.assertTrue((result_view[-1:, :, 0] == 0).all())
+                self.assertTrue((result_view[:, :1, 0] == 0).all())
+                self.assertTrue((result_view[:, -1:, 0] == 0).all())
 
         imr.notify(check, codon="unique")
 
@@ -210,6 +316,69 @@ class ColortableImageSourceTest( ImageSourcesTestBase ):
 
                 img.setPixel(i, 4, QColor(0,0,255).rgba())
                 img.setPixel(i, 5, QColor(0,0,255).rgba())
+            assert img.size() == result.size()
+            assert img == result
+
+        imr.notify(check, codon="unique")
+
+    def testSetDirty( self ):
+        def checkAllDirty( rect ):
+            self.assertTrue( rect.isEmpty() )
+
+        def checkDirtyRect( rect ):
+            self.assertEqual( rect.x(), 34 )
+            self.assertEqual( rect.y(), 12 )
+            self.assertEqual( rect.width(), 3 )
+            self.assertEqual( rect.height(), 22  )
+
+        # should mark everything dirty
+        self.ims.isDirty.connect( checkAllDirty )
+        self.ims.setDirty((slice(34,None), slice(12,34)))
+        self.ims.isDirty.disconnect( checkAllDirty )
+
+        # dirty subrect
+        self.ims.isDirty.connect( checkDirtyRect )
+        self.ims.setDirty((slice(34,37), slice(12,34)))
+        self.ims.isDirty.disconnect( checkDirtyRect )
+
+class ColortableImageSourceTest2( ImageSourcesTestBase ):
+    def setUp( self ):
+        if 'TRAVIS' in os.environ:
+            # Colortable requests require vigra, which is not installed on our Travis-CI build.
+            # Skip this test on Travis-CI.
+            import nose
+            raise nose.SkipTest
+
+        super( ColortableImageSourceTest2, self ).setUp()
+        self.seg = numpy.zeros((6,7), dtype=numpy.uint32)
+        self.seg = numpy.ma.masked_array(self.seg, mask=numpy.zeros(self.seg.shape, dtype=bool), shrink=False)
+        self.seg[0:2,:] = 0
+        self.seg[1,:] = numpy.ma.masked
+        self.seg[2:4,:] = 1
+        self.seg[3,:] = numpy.ma.masked
+        self.seg[4:6,:] = 2
+        self.seg[5,:] = numpy.ma.masked
+        self.ars = _ArraySource2d(self.seg)
+        self.ctable = [QColor(255,0,0).rgba(), QColor(0,255,0).rgba(), QColor(0,0,255).rgba()]
+        self.layer = ColortableLayer(self.ars, self.ctable)
+        self.ims = ColortableImageSource( self.ars, self.layer )
+
+    def testRequest( self ):
+        imr = self.ims.request(QRect(0,0,512,512))
+        def check(result, codon):
+            self.assertEqual(codon, "unique")
+            self.assertTrue(type(result) == QImage)
+            img = QImage(7,6, QImage.Format_ARGB32)
+            for i in range(7):
+                img.setPixel(i, 0, QColor(255,0,0,255).rgba())
+                img.setPixel(i, 1, QColor(0,0,0,0).rgba())
+
+                img.setPixel(i, 2, QColor(0,255,0,255).rgba())
+                img.setPixel(i, 3, QColor(0,0,0,0).rgba())
+
+                img.setPixel(i, 4, QColor(0,0,255,255).rgba())
+                img.setPixel(i, 5, QColor(0,0,0,0).rgba())
+
             assert img.size() == result.size()
             assert img == result
 

--- a/volumina/layer.py
+++ b/volumina/layer.py
@@ -185,6 +185,7 @@ class Layer( QObject ):
         self._toolTip = ""
         self._cleaned_up = False
 
+        self._updateNumberOfChannels()
         for datasource in filter(None, self._datasources):
             datasource.numberOfChannelsChanged.connect( self._updateNumberOfChannels )
 
@@ -203,9 +204,22 @@ class Layer( QObject ):
         self.contexts = []
 
     def _updateNumberOfChannels(self):
-        newchannels = self._datasources[0].numberOfChannels
-        for datasource in self._datasources[1:]:
-            newchannels = min( datasource.numberOfChannels, newchannels )
+        # As there can many datasources and they can all be None,
+        # grab numberOfChannels for those that are defined.
+        # That is, if there are any datasources.
+        newchannels = []
+        for i in xrange(len(self._datasources)):
+            if self._datasources[i] is not None:
+                newchannels.append(self._datasources[i].numberOfChannels)
+
+        # If the datasources are all None or there aren't any,
+        # default to 1 channel as we must have at least 1.
+        if not newchannels:
+            newchannels = [1]
+
+        # Get the smallest number of channels that works for all.
+        newchannels = min(newchannels)
+
         if newchannels != self.numberOfChannels:
             # Update property (emits signal)
             self.numberOfChannels = newchannels

--- a/volumina/layer.py
+++ b/volumina/layer.py
@@ -185,7 +185,6 @@ class Layer( QObject ):
         self._toolTip = ""
         self._cleaned_up = False
 
-        self._updateNumberOfChannels()
         for datasource in filter(None, self._datasources):
             datasource.numberOfChannelsChanged.connect( self._updateNumberOfChannels )
 
@@ -204,22 +203,9 @@ class Layer( QObject ):
         self.contexts = []
 
     def _updateNumberOfChannels(self):
-        # As there can be many datasources and they can all be None,
-        # grab numberOfChannels for those that are defined.
-        # That is, if there are any datasources.
-        newchannels = []
-        for i in xrange(len(self._datasources)):
-            if self._datasources[i] is not None:
-                newchannels.append(self._datasources[i].numberOfChannels)
-
-        # If the datasources are all None or there aren't any,
-        # default to 1 channel as we must have at least 1.
-        if not newchannels:
-            newchannels = [1]
-
-        # Get the smallest number of channels that works for all.
-        newchannels = min(newchannels)
-
+        newchannels = self._datasources[0].numberOfChannels
+        for datasource in self._datasources[1:]:
+            newchannels = min( datasource.numberOfChannels, newchannels )
         if newchannels != self.numberOfChannels:
             # Update property (emits signal)
             self.numberOfChannels = newchannels

--- a/volumina/layer.py
+++ b/volumina/layer.py
@@ -204,7 +204,7 @@ class Layer( QObject ):
         self.contexts = []
 
     def _updateNumberOfChannels(self):
-        # As there can many datasources and they can all be None,
+        # As there can be many datasources and they can all be None,
         # grab numberOfChannels for those that are defined.
         # That is, if there are any datasources.
         newchannels = []

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -504,9 +504,11 @@ class ColortableImageRequest( object ):
                         # Create the larger color table.
                         _colorTable = np.empty(_colorTable_shape, dtype=_colorTable.dtype)
 
-                        # Make sure the first color is transparent and copy the rest of the colors over.
-                        _colorTable[0] = 0
+                        # Copy the rest of the colors over.
                         _colorTable[1:] = self._colorTable
+
+                        # Make sure the first color is transparent.
+                        _colorTable[0] = 0
 
                 # Make masked values transparent.
                 a = np.ma.filled(a, 0)

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -449,13 +449,8 @@ class ColortableImageRequest( object ):
                         a += 1
 
                         # Insert space for transparent color as needed.
-                        _colorTable_shape = list(_colorTable.shape)
-                        _colorTable_shape[0] += 1
-                        _colorTable_shape = tuple(_colorTable_shape)
-
-                        _colorTable = np.empty(_colorTable_shape, dtype=_colorTable.dtype)
-
-                        _colorTable[1:] = self._colorTable
+                        _colorTable = np.empty((1,) + _colorTable.shape[1:], dtype=_colorTable.dtype)
+                        _colorTable = np.vstack([_colorTable, self._colorTable])
 
                     # Make sure the first color is transparent.
                     _colorTable[0] = 0

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -445,7 +445,7 @@ class ColortableImageRequest( object ):
                                 # Try to wrap the max value to a smaller value of the same color.
                                 a[a == np.iinfo(a.dtype).max] %= len(_colorTable)
 
-                        # Insert space for transparent color as needed and shift labels up.
+                        # Insert space for transparent color and shift labels up.
                         _colorTable = np.insert(_colorTable, 0, 0, axis=0)
                         a += 1
                     else:

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -430,8 +430,6 @@ class ColortableImageRequest( object ):
             if np.ma.is_masked(a):
                 # Add transparent color at the beginning of the colortable as needed.
                 if (_colorTable[0, 3] != 0):
-                    _colorTable = _colorTable.copy()  # Must add transparent color. Preserve original colortable.
-
                     # If label 0 is unused, it can be transparent. Otherwise, the transparent color must be inserted.
                     if (a.min() == 0):
                         # If it will overflow simply promote the type. Otherwise skip. Assume unsigned.

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -469,7 +469,7 @@ class ColortableImageRequest( object ):
                                            + " sense. If so, feel free to comment this assert and proceed with caution.")
                                     # Lots of colors. This will be tricky and may be slow.
 
-                                    # Find the first non-consecutive value. This means a color/value were unused and
+                                    # Find the first non-consecutive value. This means a color/value was unused and
                                     # can be safely dropped from the table.
                                     a_values = np.unique(a)
                                     a_gap_mask = (np.ediff1d(a_values, to_begin=1) > 1)

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -472,7 +472,7 @@ class ColortableImageRequest( object ):
                                     a_gap_value = a_labels[a_nonconsecutive_label_mask][0]
                                     expand_colorTable = False
 
-                                    # Reduce everything at the non-consecutive value and above by 1.
+                                    # Reduce everything at the skipped label and above by 1.
                                     a -= (a >= a_gap_value)
                                     # Overwrite the unused color by shifting all colors before it up.
                                     # This way we have room for the transparent color at the beginning.

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -458,10 +458,10 @@ class ColortableImageRequest( object ):
 
                                     # Find non-consecutive labels. Get a mask for the first skipped label.
                                     a_labels = np.unique(a)
-                                    a_gap_mask = (np.ediff1d(a_labels, to_begin=1) > 1)
-                                    a_gap_mask &= (a_gap_mask.cumsum() == 1)
+                                    a_nonconsecutive_label_mask = (np.ediff1d(a_labels, to_begin=1) > 1)
+                                    a_nonconsecutive_label_mask &= (a_nonconsecutive_label_mask.cumsum() == 1)
 
-                                    assert(a_gap_mask.any(),
+                                    assert(a_nonconsecutive_label_mask.any(),
                                            "Trying to display a masked array using a ColortableImageSource. However, a"
                                            + " a transparent color was not found and it was not possible to easily add"
                                            + " one as all valid integer values are already in use in the image. Add a"
@@ -469,7 +469,7 @@ class ColortableImageRequest( object ):
                                     )
 
                                     # Extract the gap value.
-                                    a_gap_value = a_labels[a_gap_mask][0]
+                                    a_gap_value = a_labels[a_nonconsecutive_label_mask][0]
                                     expand_colorTable = False
 
                                     # Reduce everything at the non-consecutive value and above by 1.

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -439,10 +439,7 @@ class ColortableImageRequest( object ):
                     expand_colorTable = False
                     if (a.min() == 0):
                         expand_colorTable = True
-                        # If we will have a overflow error, promote to the next largest type, if possible.
-                        #
-                        # If we can't promote further, try tricks like wrapping or finding gaps to affect the
-                        # same change.
+                        # If it will overflow simply promote the type. Otherwise skip. Assume unsigned.
                         if (a.max() == np.iinfo(a.dtype).max):
                             if a.dtype.type == np.uint8:
                                 a = np.asarray(a, dtype=np.uint16)

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -443,39 +443,13 @@ class ColortableImageRequest( object ):
                             elif a.dtype.type == np.uint16:
                                 a = np.asarray(a, dtype=np.uint32)
                             elif a.dtype.type == np.uint32:
-                                # We have reached the largest type VIGRA supports. Need to free up a label/color.
-                                if np.iinfo(a.dtype).max >= len(_colorTable):
-                                    # Try to wrap the max value to a smaller value of the same color.
-                                    a[a == np.iinfo(a.dtype).max] %= len(_colorTable)
-                                else:
-                                    assert(False,
-                                           "Code for this feature has been added below and \"should\" work as is."
-                                           + " However, it is untested and is believed to be slow because the size of"
-                                           + " the colortable is quite large and the number of integers is believed to"
-                                           + " be quite large. Check to make sure what you are doing makes sense. If"
-                                           + " so, feel free to comment this assert and proceed with caution.")
-                                    # Otherwise, drop the first unused color from the colortable and remap everything.
+                                assert(np.iinfo(a.dtype).max >= len(_colorTable),
+                                       "This is a very large colortable. If it is indeed needed, add a transparent"
+                                       " color at the beginning of the colortable for displaying masked arrays.")
 
-                                    # Find non-consecutive labels. Get a mask for the first skipped label.
-                                    a_labels = np.unique(a)
-                                    a_nonconsecutive_label_mask = (np.ediff1d(a_labels, to_begin=1) > 1)
-                                    a_nonconsecutive_label_mask &= (a_nonconsecutive_label_mask.cumsum() == 1)
+                                # Try to wrap the max value to a smaller value of the same color.
+                                a[a == np.iinfo(a.dtype).max] %= len(_colorTable)
 
-                                    assert(a_nonconsecutive_label_mask.any(),
-                                           "Trying to display a masked array using a ColortableImageSource. However, a"
-                                           + " transparent color was not found and it was not possible to easily add"
-                                           + " one as all valid integer values are already in use in the image. Add a"
-                                           + " transparent color at the beginning of your colortable."
-                                    )
-
-                                    # Extract the gap value.
-                                    a_nonconsecutive_label = a_labels[a_nonconsecutive_label_mask][0]
-                                    expand_colorTable = False
-
-                                    # Shift all colors below the unused one up, freeing space for the transparent color.
-                                    _colorTable[1:a_nonconsecutive_label] = _colorTable[:a_nonconsecutive_label-1]
-                                    # Reduce everything at the skipped label and above by 1.
-                                    a -= (a >= a_nonconsecutive_label)
 
                         a += 1
 

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -435,9 +435,9 @@ class ColortableImageRequest( object ):
                         # If it will overflow simply promote the type. Otherwise skip. Assume unsigned.
                         if (a.max() == np.iinfo(a.dtype).max):
                             if a.dtype.type == np.uint8:
-                                a = np.asarray(a, dtype=np.uint16)
+                                a = np.asanyarray(a, dtype=np.uint16)
                             elif a.dtype.type == np.uint16:
-                                a = np.asarray(a, dtype=np.uint32)
+                                a = np.asanyarray(a, dtype=np.uint32)
                             elif a.dtype.type == np.uint32:
                                 assert(np.iinfo(a.dtype).max >= len(_colorTable),
                                        "This is a very large colortable. If it is indeed needed, add a transparent"

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -428,7 +428,7 @@ class ColortableImageRequest( object ):
             # If we have a masked array with a non-trivial mask, ensure that mask is made transparent.
             _colorTable = self._colorTable
             if np.ma.is_masked(a):
-                # If there is no transparency color at the beginning of the colortable, add one. Skip otherwise.
+                # Add transparent color at the beginning of the colortable as needed.
                 if (_colorTable[0, 3] != 0):
                     _colorTable = _colorTable.copy()  # Must add transparent color. Preserve original colortable.
 

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -463,7 +463,7 @@ class ColortableImageRequest( object ):
 
                                     assert(a_nonconsecutive_label_mask.any(),
                                            "Trying to display a masked array using a ColortableImageSource. However, a"
-                                           + " a transparent color was not found and it was not possible to easily add"
+                                           + " transparent color was not found and it was not possible to easily add"
                                            + " one as all valid integer values are already in use in the image. Add a"
                                            + " transparent color at the beginning of your colortable."
                                     )

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -445,10 +445,9 @@ class ColortableImageRequest( object ):
                                 # Try to wrap the max value to a smaller value of the same color.
                                 a[a == np.iinfo(a.dtype).max] %= len(_colorTable)
 
-                        a += 1
-
-                        # Insert space for transparent color as needed.
+                        # Insert space for transparent color as needed and shift labels up.
                         _colorTable = np.insert(_colorTable, 0, 0, axis=0)
+                        a += 1
                     else:
                         # Make sure the first color is transparent.
                         _colorTable = self._colorTable.copy()

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -456,8 +456,8 @@ class ColortableImageRequest( object ):
                                            + " sense. If so, feel free to comment this assert and proceed with caution.")
                                     # Otherwise, drop the first unused color from the colortable and remap everything.
 
-                                    # Find the first non-consecutive value. This means a color/value was unused and
-                                    # can be safely dropped from the table.
+                                    # Find the first non-consecutive label. This means a label was unused and can be
+                                    # safely dropped from the table.
                                     a_values = np.unique(a)
                                     a_gap_mask = (np.ediff1d(a_values, to_begin=1) > 1)
                                     a_gap_mask &= (a_gap_mask.cumsum() == 1)

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -300,8 +300,6 @@ class AlphaModulatedImageRequest( object ):
             self.logger.debug("toImage (%dx%d, normalize=%r) took %f msec. (array req: %f, wait: %f, img: %f)" % (img.width(), img.height(), normalize, tTOT, tAR, tWAIT, tImg))
             
         return img
-        
-        return img
             
     def notify( self, callback, **kwargs ):
         self._arrayreq.notify(self._onNotify, package = (callback, kwargs))

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -492,7 +492,6 @@ class ColortableImageRequest( object ):
                                     # Overwrite the unused color by shifting all colors before it up.
                                     # This way we have room for the transparent color at the beginning.
                                     _colorTable[1:a_gap_value] = _colorTable[:a_gap_value-1]
-                                    _colorTable[0] = 0
 
                         a += 1
 

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -436,8 +436,9 @@ class ColortableImageRequest( object ):
 
                     # Next we want to insert the transparent color at the beginning if it doesn't exist.
                     # First verify that the first color is not in use. If it is, try make sure it isn't.
-                    expand_colorTable = True
+                    expand_colorTable = False
                     if (a.min() == 0):
+                        expand_colorTable = True
                         # If we will have a overflow error, promote to the next largest type, if possible.
                         #
                         # If we can't promote further, try tricks like wrapping or finding gaps to affect the

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -450,7 +450,6 @@ class ColortableImageRequest( object ):
                                 # Try to wrap the max value to a smaller value of the same color.
                                 a[a == np.iinfo(a.dtype).max] %= len(_colorTable)
 
-
                         a += 1
 
                     # Insert space for transparent color as needed.

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -434,11 +434,10 @@ class ColortableImageRequest( object ):
                     if (a.min() == 0):
                         # If it will overflow simply promote the type. Otherwise skip. Assume unsigned.
                         if (a.max() == np.iinfo(a.dtype).max):
-                            if a.dtype.type == np.uint8:
-                                a = np.asanyarray(a, dtype=np.uint16)
-                            elif a.dtype.type == np.uint16:
-                                a = np.asanyarray(a, dtype=np.uint32)
-                            elif a.dtype.type == np.uint32:
+                            a_new_dtype = np.min_scalar_type(np.iinfo(a.dtype).max + 1)
+                            if a_new_dtype <= np.dtype(np.uint32):
+                                 a = np.asanyarray(a, dtype=a_new_dtype)
+                            else:
                                 assert(np.iinfo(a.dtype).max >= len(_colorTable),
                                        "This is a very large colortable. If it is indeed needed, add a transparent"
                                        " color at the beginning of the colortable for displaying masked arrays.")

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -456,8 +456,7 @@ class ColortableImageRequest( object ):
                                            + " sense. If so, feel free to comment this assert and proceed with caution.")
                                     # Otherwise, drop the first unused color from the colortable and remap everything.
 
-                                    # Find non-consecutive labels. This means a label was unused and can be safely
-                                    # dropped from the table.
+                                    # Find non-consecutive labels. Get a mask for the first skipped label.
                                     a_values = np.unique(a)
                                     a_gap_mask = (np.ediff1d(a_values, to_begin=1) > 1)
                                     a_gap_mask &= (a_gap_mask.cumsum() == 1)

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -479,16 +479,14 @@ class ColortableImageRequest( object ):
 
                         a += 1
 
+                    # Insert space for transparent color as needed.
                     if expand_colorTable:
-                        # Add room for one more
                         _colorTable_shape = list(_colorTable.shape)
                         _colorTable_shape[0] += 1
                         _colorTable_shape = tuple(_colorTable_shape)
 
-                        # Create the larger color table.
                         _colorTable = np.empty(_colorTable_shape, dtype=_colorTable.dtype)
 
-                        # Copy the rest of the colors over.
                         _colorTable[1:] = self._colorTable
 
                     # Make sure the first color is transparent.

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -430,8 +430,7 @@ class ColortableImageRequest( object ):
             if np.ma.is_masked(a):
                 # If there is no transparency color at the beginning of the colortable, add one. Skip otherwise.
                 if (_colorTable[0, 3] != 0):
-                    # Have to modify the table. Preserve the original.
-                    _colorTable = _colorTable.copy()
+                    _colorTable = _colorTable.copy()  # Must add transparent color. Preserve original colortable.
 
                     # Next we want to insert the transparent color at the beginning if it doesn't exist.
                     # First verify that the first color is not in use. If it is, try make sure it isn't.

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -449,8 +449,7 @@ class ColortableImageRequest( object ):
                         a += 1
 
                         # Insert space for transparent color as needed.
-                        _colorTable = np.empty((1,) + _colorTable.shape[1:], dtype=_colorTable.dtype)
-                        _colorTable = np.vstack([_colorTable, self._colorTable])
+                        _colorTable = np.insert(_colorTable, 0, 0, axis=0)
                     else:
                         _colorTable = self._colorTable.copy()
 

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -474,8 +474,7 @@ class ColortableImageRequest( object ):
 
                                     # Reduce everything at the skipped label and above by 1.
                                     a -= (a >= a_gap_value)
-                                    # Overwrite the unused color by shifting all colors before it up.
-                                    # This way we have room for the transparent color at the beginning.
+                                    # Shift all colors below the unused one up, freeing space for the transparent color.
                                     _colorTable[1:a_gap_value] = _colorTable[:a_gap_value-1]
 
                         a += 1

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -507,8 +507,8 @@ class ColortableImageRequest( object ):
                         # Copy the rest of the colors over.
                         _colorTable[1:] = self._colorTable
 
-                        # Make sure the first color is transparent.
-                        _colorTable[0] = 0
+                    # Make sure the first color is transparent.
+                    _colorTable[0] = 0
 
                 # Make masked values transparent.
                 a = np.ma.filled(a, 0)

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -433,9 +433,7 @@ class ColortableImageRequest( object ):
                     _colorTable = _colorTable.copy()  # Must add transparent color. Preserve original colortable.
 
                     # If label 0 is unused, it can be transparent. Otherwise, the transparent color must be inserted.
-                    expand_colorTable = False
                     if (a.min() == 0):
-                        expand_colorTable = True
                         # If it will overflow simply promote the type. Otherwise skip. Assume unsigned.
                         if (a.max() == np.iinfo(a.dtype).max):
                             if a.dtype.type == np.uint8:
@@ -452,8 +450,7 @@ class ColortableImageRequest( object ):
 
                         a += 1
 
-                    # Insert space for transparent color as needed.
-                    if expand_colorTable:
+                        # Insert space for transparent color as needed.
                         _colorTable_shape = list(_colorTable.shape)
                         _colorTable_shape[0] += 1
                         _colorTable_shape = tuple(_colorTable_shape)

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -451,6 +451,8 @@ class ColortableImageRequest( object ):
                         # Insert space for transparent color as needed.
                         _colorTable = np.empty((1,) + _colorTable.shape[1:], dtype=_colorTable.dtype)
                         _colorTable = np.vstack([_colorTable, self._colorTable])
+                    else:
+                        _colorTable = self._colorTable.copy()
 
                     # Make sure the first color is transparent.
                     _colorTable[0] = 0

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -432,8 +432,7 @@ class ColortableImageRequest( object ):
                 if (_colorTable[0, 3] != 0):
                     _colorTable = _colorTable.copy()  # Must add transparent color. Preserve original colortable.
 
-                    # Next we want to insert the transparent color at the beginning if it doesn't exist.
-                    # First verify that the first color is not in use. If it is, try to make sure it isn't.
+                    # If label 0 is unused, it can be transparent. Otherwise, the transparent color must be inserted.
                     expand_colorTable = False
                     if (a.min() == 0):
                         expand_colorTable = True

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -449,11 +449,11 @@ class ColortableImageRequest( object ):
                                     a[a == np.iinfo(a.dtype).max] %= len(_colorTable)
                                 else:
                                     assert(False,
-                                           "Code for this feature has been added below and \"should\" work"
-                                           + " as is. However, it is untested and is believed to be slow because the"
-                                           + " size of the colortable is quite large and the number of integers is"
-                                           + " believed to be quite large. Check to make sure what you are doing makes"
-                                           + " sense. If so, feel free to comment this assert and proceed with caution.")
+                                           "Code for this feature has been added below and \"should\" work as is."
+                                           + " However, it is untested and is believed to be slow because the size of"
+                                           + " the colortable is quite large and the number of integers is believed to"
+                                           + " be quite large. Check to make sure what you are doing makes sense. If"
+                                           + " so, feel free to comment this assert and proceed with caution.")
                                     # Otherwise, drop the first unused color from the colortable and remap everything.
 
                                     # Find non-consecutive labels. Get a mask for the first skipped label.

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -433,7 +433,7 @@ class ColortableImageRequest( object ):
                     _colorTable = _colorTable.copy()  # Must add transparent color. Preserve original colortable.
 
                     # Next we want to insert the transparent color at the beginning if it doesn't exist.
-                    # First verify that the first color is not in use. If it is, try make sure it isn't.
+                    # First verify that the first color is not in use. If it is, try to make sure it isn't.
                     expand_colorTable = False
                     if (a.min() == 0):
                         expand_colorTable = True

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -451,10 +451,9 @@ class ColortableImageRequest( object ):
                         # Insert space for transparent color as needed.
                         _colorTable = np.insert(_colorTable, 0, 0, axis=0)
                     else:
+                        # Make sure the first color is transparent.
                         _colorTable = self._colorTable.copy()
-
-                    # Make sure the first color is transparent.
-                    _colorTable[0] = 0
+                        _colorTable[0] = 0
 
                 # Make masked values transparent.
                 a = np.ma.filled(a, 0)

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -428,8 +428,7 @@ class ColortableImageRequest( object ):
             # If we have a masked array with a non-trivial mask, ensure that mask is made transparent.
             _colorTable = self._colorTable
             if np.ma.is_masked(a):
-                # If there is no transparency color at the beginning of the colortable, add one for the mask.
-                # Otherwise, we use the colortable as is.
+                # If there is no transparency color at the beginning of the colortable, add one. Skip otherwise.
                 if (_colorTable[0, 3] != 0):
                     # Have to modify the table. Preserve the original.
                     _colorTable = _colorTable.copy()

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -450,7 +450,7 @@ class ColortableImageRequest( object ):
                         a += 1
                     else:
                         # Make sure the first color is transparent.
-                        _colorTable = self._colorTable.copy()
+                        _colorTable = _colorTable.copy()
                         _colorTable[0] = 0
 
                 # Make masked values transparent.

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -472,10 +472,10 @@ class ColortableImageRequest( object ):
                                     a_gap_value = a_labels[a_nonconsecutive_label_mask][0]
                                     expand_colorTable = False
 
-                                    # Reduce everything at the skipped label and above by 1.
-                                    a -= (a >= a_gap_value)
                                     # Shift all colors below the unused one up, freeing space for the transparent color.
                                     _colorTable[1:a_gap_value] = _colorTable[:a_gap_value-1]
+                                    # Reduce everything at the skipped label and above by 1.
+                                    a -= (a >= a_gap_value)
 
                         a += 1
 

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -456,8 +456,8 @@ class ColortableImageRequest( object ):
                                            + " sense. If so, feel free to comment this assert and proceed with caution.")
                                     # Otherwise, drop the first unused color from the colortable and remap everything.
 
-                                    # Find the first non-consecutive label. This means a label was unused and can be
-                                    # safely dropped from the table.
+                                    # Find non-consecutive labels. This means a label was unused and can be safely
+                                    # dropped from the table.
                                     a_values = np.unique(a)
                                     a_gap_mask = (np.ediff1d(a_values, to_begin=1) > 1)
                                     a_gap_mask &= (a_gap_mask.cumsum() == 1)

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -457,8 +457,8 @@ class ColortableImageRequest( object ):
                                     # Otherwise, drop the first unused color from the colortable and remap everything.
 
                                     # Find non-consecutive labels. Get a mask for the first skipped label.
-                                    a_values = np.unique(a)
-                                    a_gap_mask = (np.ediff1d(a_values, to_begin=1) > 1)
+                                    a_labels = np.unique(a)
+                                    a_gap_mask = (np.ediff1d(a_labels, to_begin=1) > 1)
                                     a_gap_mask &= (a_gap_mask.cumsum() == 1)
 
                                     assert(a_gap_mask.any(),
@@ -469,7 +469,7 @@ class ColortableImageRequest( object ):
                                     )
 
                                     # Extract the gap value.
-                                    a_gap_value = a_values[a_gap_mask][0]
+                                    a_gap_value = a_labels[a_gap_mask][0]
                                     expand_colorTable = False
 
                                     # Reduce everything at the non-consecutive value and above by 1.

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -461,7 +461,6 @@ class ColortableImageRequest( object ):
                                     a_gap_mask = (np.ediff1d(a_values, to_begin=1) > 1)
                                     a_gap_mask &= (a_gap_mask.cumsum() == 1)
 
-                                    # If this assertion occurs, chances are everything is going really slow.
                                     assert(a_gap_mask.any(),
                                            "Trying to display a masked array using a ColortableImageSource. However, a"
                                            + " a transparent color was not found and it was not possible to easily add"

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -469,13 +469,13 @@ class ColortableImageRequest( object ):
                                     )
 
                                     # Extract the gap value.
-                                    a_gap_value = a_labels[a_nonconsecutive_label_mask][0]
+                                    a_nonconsecutive_label = a_labels[a_nonconsecutive_label_mask][0]
                                     expand_colorTable = False
 
                                     # Shift all colors below the unused one up, freeing space for the transparent color.
-                                    _colorTable[1:a_gap_value] = _colorTable[:a_gap_value-1]
+                                    _colorTable[1:a_nonconsecutive_label] = _colorTable[:a_nonconsecutive_label-1]
                                     # Reduce everything at the skipped label and above by 1.
-                                    a -= (a >= a_gap_value)
+                                    a -= (a >= a_nonconsecutive_label)
 
                         a += 1
 

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -432,7 +432,7 @@ class ColortableImageRequest( object ):
                 if (_colorTable[0, 3] != 0):
                     # If label 0 is unused, it can be transparent. Otherwise, the transparent color must be inserted.
                     if (a.min() == 0):
-                        # If it will overflow simply promote the type. Otherwise skip. Assume unsigned.
+                        # If it will overflow simply promote the type. Unless we have reached the max VIGRA type.
                         if (a.max() == np.iinfo(a.dtype).max):
                             a_new_dtype = np.min_scalar_type(np.iinfo(a.dtype).max + 1)
                             if a_new_dtype <= np.dtype(np.uint32):

--- a/volumina/pixelpipeline/imagesources.py
+++ b/volumina/pixelpipeline/imagesources.py
@@ -449,16 +449,9 @@ class ColortableImageRequest( object ):
                             elif a.dtype.type == np.uint16:
                                 a = np.asarray(a, dtype=np.uint32)
                             elif a.dtype.type == np.uint32:
-                                # We have reached the largest type VIGRA supports. Time for some tricks.
-
-                                # Try the following.
-                                #
-                                # First, see if we can't just wrap the largest value on to another value in the
-                                # colortable. This is the color it would have been anyways.
-                                #
-                                # Second, see if we can't find an unused color (number that doesn't appear) and then
-                                # drop this color (number) from the table (image).
+                                # We have reached the largest type VIGRA supports. Need to free up a label/color.
                                 if np.iinfo(a.dtype).max >= len(_colorTable):
+                                    # Try to wrap the max value to a smaller value of the same color.
                                     a[a == np.iinfo(a.dtype).max] %= len(_colorTable)
                                 else:
                                     assert(False,
@@ -467,7 +460,7 @@ class ColortableImageRequest( object ):
                                            + " size of the colortable is quite large and the number of integers is"
                                            + " believed to be quite large. Check to make sure what you are doing makes"
                                            + " sense. If so, feel free to comment this assert and proceed with caution.")
-                                    # Lots of colors. This will be tricky and may be slow.
+                                    # Otherwise, drop the first unused color from the colortable and remap everything.
 
                                     # Find the first non-consecutive value. This means a color/value was unused and
                                     # can be safely dropped from the table.


### PR DESCRIPTION
Provides support for masked arrays in volumina. In most cases, this is a series of minor fixes to volumina to ensure support of masked arrays. In a few cases, more heavy duty code is required to bring about support. Most of the support is already available to thanks to ( https://github.com/hmeine/qimage2ndarray ). Masked arrays appear basically the same NumPy ndarrays except that they mask results. In an image source, the masked regions are made transparent. This is related to several issues ( https://github.com/ilastik/ilastik/issues/1076 ) (  https://github.com/ilastik/lazyflow/issues/162 ) ( https://github.com/ilastik/volumina/issues/151 ).