### PR TITLE
Setting tiling block size based on slice shape

### DIFF
--- a/volumina/imageScene2D.py
+++ b/volumina/imageScene2D.py
@@ -305,9 +305,15 @@ class ImageScene2D(QGraphicsScene):
         and when the underlying data changes.
 
         """
+        DEFAULT_TILE_WIDTH = 512 
+        
         self.resetAxes(finish=False)
+        
+        tileWidth = self.tileWidth
+        if self.tileWidth is None:
+            tileWidth = DEFAULT_TILE_WIDTH
 
-        self._tiling = Tiling(self._dataShape, self.data2scene, name=self.name)
+        self._tiling = Tiling(self._dataShape, self.data2scene, name=self.name, blockSize=tileWidth)
 
         self._tileProvider = TileProvider(self._tiling, self._stackedImageSources)
         self._tileProvider.sceneRectChanged.connect(self.invalidateViewports)
@@ -382,6 +388,7 @@ class ImageScene2D(QGraphicsScene):
         self._offsetX = 0
         self._offsetY = 0
         self.name = name
+        self.tileWidth = None
 
         self._stackedImageSources = StackedImageSources(LayerStackModel())
         self._showTileOutlines = False

--- a/volumina/tiling.py
+++ b/volumina/tiling.py
@@ -92,7 +92,7 @@ class Tiling(object):
     """
 
     def __init__(self, sliceShape, data2scene=QTransform(),
-                 blockSize=256, overlap=0, overlap_draw=1e-3,
+                 blockSize=512, overlap=0, overlap_draw=1e-3,
                  name="Unnamed Tiling"):
         """
         Args:

--- a/volumina/volumeEditorWidget.py
+++ b/volumina/volumeEditorWidget.py
@@ -545,6 +545,34 @@ class VolumeEditorWidget(QWidget):
                                                   None ) )
         self._debugActions.append( actionBlockGui )
 
+        def changeTileWidth():
+            '''Change tile width (tile block size) and reset image-scene'''
+            dlg = QDialog(self)
+            layout = QHBoxLayout()
+            layout.addWidget( QLabel("Tile Width:") )
+
+            spinBox = QSpinBox( parent=dlg )
+            spinBox.setRange( 128, 10*1024 )
+            spinBox.setValue(512)
+            
+            if self.editor.imageScenes[0].tileWidth:
+                spinBox.setValue( self.editor.imageScenes[0].tileWidth )
+                
+            layout.addWidget( spinBox )
+            okButton = QPushButton( "OK", parent=dlg )
+            okButton.clicked.connect( dlg.accept )
+            layout.addWidget( okButton )
+            dlg.setLayout( layout )
+            dlg.setModal(True)
+            
+            if dlg.exec_() == QDialog.Accepted:
+                for s in self.editor.imageScenes:
+                    if s.tileWidth != spinBox.value():
+                        s.tileWidth = spinBox.value()
+                        s.reset()
+                        
+        self._viewMenu.addAction( "Set Tile Width..." ).triggered.connect(changeTileWidth)
+
         # ------ Separator ------
         self._viewMenu.addAction("").setSeparator(True)
 
@@ -578,34 +606,6 @@ class VolumeEditorWidget(QWidget):
         def resetAxes():
             self.editor.imageScenes[self.editor._lastImageViewFocus].resetAxes()
         self._viewMenu.addAction( "Reset axes" ).triggered.connect(resetAxes)
-
-        def changeTileWidth():
-            '''Change tile width (tile block size) and reset image-scene'''
-            dlg = QDialog(self)
-            layout = QHBoxLayout()
-            layout.addWidget( QLabel("Tile Width:") )
-
-            spinBox = QSpinBox( parent=dlg )
-            spinBox.setRange( 128, 10*1024 )
-            spinBox.setValue(512)
-            
-            if self.editor.imageScenes[0].tileWidth:
-                spinBox.setValue( self.editor.imageScenes[0].tileWidth )
-                
-            layout.addWidget( spinBox )
-            okButton = QPushButton( "OK", parent=dlg )
-            okButton.clicked.connect( dlg.accept )
-            layout.addWidget( okButton )
-            dlg.setLayout( layout )
-            dlg.setModal(True)
-            
-            if dlg.exec_() == QDialog.Accepted:
-                for s in self.editor.imageScenes:
-                    if s.tileWidth != spinBox.value():
-                        s.tileWidth = spinBox.value()
-                        s.reset()
-                        
-        self._viewMenu.addAction( "Set Tile Width..." ).triggered.connect(changeTileWidth)
 
         def centerImage():
             self.editor.imageViews[self.editor._lastImageViewFocus].centerImage()

--- a/volumina/volumeEditorWidget.py
+++ b/volumina/volumeEditorWidget.py
@@ -579,6 +579,34 @@ class VolumeEditorWidget(QWidget):
             self.editor.imageScenes[self.editor._lastImageViewFocus].resetAxes()
         self._viewMenu.addAction( "Reset axes" ).triggered.connect(resetAxes)
 
+        def changeTileWidth():
+            '''Change tile width (tile block size) and reset image-scene'''
+            dlg = QDialog(self)
+            layout = QHBoxLayout()
+            layout.addWidget( QLabel("Tile Width:") )
+
+            spinBox = QSpinBox( parent=dlg )
+            spinBox.setRange( 128, 10*1024 )
+            spinBox.setValue(512)
+            
+            if self.editor.imageScenes[0].tileWidth:
+                spinBox.setValue( self.editor.imageScenes[0].tileWidth )
+                
+            layout.addWidget( spinBox )
+            okButton = QPushButton( "OK", parent=dlg )
+            okButton.clicked.connect( dlg.accept )
+            layout.addWidget( okButton )
+            dlg.setLayout( layout )
+            dlg.setModal(True)
+            
+            if dlg.exec_() == QDialog.Accepted:
+                for s in self.editor.imageScenes:
+                    if s.tileWidth != spinBox.value():
+                        s.tileWidth = spinBox.value()
+                        s.reset()
+                        
+        self._viewMenu.addAction( "Set Tile Width..." ).triggered.connect(changeTileWidth)
+
         def centerImage():
             self.editor.imageViews[self.editor._lastImageViewFocus].centerImage()
         actionCenterImage = self._viewMenu.addAction( "Center image" )


### PR DESCRIPTION
When loading videos with high resolution (eg: 3072x3072 larvae videos), the default current tiling block size of 256 creates a lot of tiles and therefore scrolling from frame to frame becomes really slow. We are now choosing the block size based on slice shape (only if it exceeds the default value 256). I tested this of 2D and 3D data sets.

@stuarteberg I think the code is safe, but could you review it just in case?