### PR TITLE
Enables drawing within the (transparent) HUD area at the top of the viewports

### DIFF
--- a/volumina/eventswitch.py
+++ b/volumina/eventswitch.py
@@ -25,6 +25,7 @@ from PyQt4.QtGui import QMouseEvent
 from abc import ABCMeta, abstractmethod
 
 from pixelpipeline.asyncabcs import _has_attributes
+from imageView2D import ImageView2D
 
 class InterpreterABC:
     __metaclass__ = ABCMeta
@@ -96,8 +97,10 @@ class EventSwitch( QObject ):
         else:
             # prevent double delivery of unhandled mouse events that
             # bubble up from the underlying viewport
-            if not isinstance(event, QMouseEvent):
-                return self._interpreter.eventFilter(watched, event)
+            if isinstance(event, QMouseEvent):
+                if isinstance(watched, ImageView2D):
+                    return self._interpreter.eventFilter(watched, event)
+                else:
+                    return False
             else:
-                return False
-
+                return self._interpreter.eventFilter(watched, event)

--- a/volumina/sliceSelectorHud.py
+++ b/volumina/sliceSelectorHud.py
@@ -253,6 +253,7 @@ class ImageView2DHud(QWidget):
     exportButtonClicked = pyqtSignal()
     def __init__(self, parent ):
         QWidget.__init__(self, parent)
+        self.setMouseTracking(True)
 
         self.layout = QHBoxLayout()
         self.setLayout(self.layout)


### PR DESCRIPTION
Previously, all mouse events not originating from viewports were filtered out. With the changes introduced by this PR, events from the parent of the respective viewport, which is ```ImageView2D``` are also accepted. (The HUD events are propagated to those ```ImageView2D``` as well).

I didn't do a terrible amount of testing, but it seems to work.