### PR TITLE
Do not handle mouse click events twice

### DIFF
--- a/volumina/interpreter.py
+++ b/volumina/interpreter.py
@@ -113,6 +113,7 @@ class ClickInterpreter(QObject):
             pos = [int(i) for i in pos]
             pos = [self.posModel.time] + pos + [self.posModel.channel]
             self._onClick(self._layer, tuple(pos), event.pos())
+            event.accept()
             return True
         else:
             return self.baseInterpret.eventFilter(watched, event)

--- a/volumina/navigationController.py
+++ b/volumina/navigationController.py
@@ -208,6 +208,7 @@ class NavigationInterpreter(QObject):
 
         pos = event.pos()
         imageview.customContextMenuRequested.emit( pos )
+        event.accept()
         return True
 
     def _itemsAt(self, imageview, pos):
@@ -227,6 +228,7 @@ class NavigationInterpreter(QObject):
 
         dataMousePos = imageview.mapScene2Data(imageview.mapToScene(event.pos()))
         self._navCtrl.navigateToPoint(dataMousePos.x(), dataMousePos.y(), self._navCtrl._views.index(imageview))
+        event.accept()
         return True
 
     ###


### PR DESCRIPTION
Set click events to accepted when they are handled, because otherwise the right-click context
menu of object classification and tracking showed up twice.

I verified that this works for ObjectClassification and Tracking with ObjectClassification on Mac.
And it still accepts clicks between the HUD buttons.