### PR TITLE
refactor: declare each slot explicitly

### DIFF
--- a/tests/datasourcefactories_tests.py
+++ b/tests/datasourcefactories_tests.py
@@ -35,10 +35,10 @@ except:
 
 if hasLazyflow:
     class OpPiper(Operator):
-        
-        inputSlots = [InputSlot("Input")]
-        outputSlots = [OutputSlot("Output")]
-        
+
+        Input = InputSlot()
+        Output = OutputSlot()
+
         def setupOutputs(self):
             
             self.outputs["Output"].meta.assignFrom(self.inputs["Input"].meta)

--- a/volumina/_testing/from_lazyflow.py
+++ b/volumina/_testing/from_lazyflow.py
@@ -52,10 +52,10 @@ class OpDelay(OpArrayPiper):
 class OpDataProvider5D(Operator):
     name = "Data Provider 5D"
     category = "Input"
-    
-    inputSlots = [InputSlot("Changedata")]
-    outputSlots = [OutputSlot("Data5D")]
-    
+
+    Changedata = InputSlot()
+    Data5D = OutputSlot()
+
     def __init__(self, g, fn):
         Operator.__init__(self,g)
         self._data = np.load(fn)

--- a/volumina/pixelpipeline/_testing.py
+++ b/volumina/pixelpipeline/_testing.py
@@ -58,8 +58,8 @@ if has_lazyflow:
         name = "Data Provider"
         category = "Input"
 
-        inputSlots = [InputSlot("Changedata", optional=True)]
-        outputSlots = [OutputSlot("Data")]
+        Changedata = InputSlot(optional=True)
+        Data = OutputSlot("Data")
 
         def __init__(self, voluminaData, graph=None, parent=None):
             """


### PR DESCRIPTION
Declaring operator slots with a list is deprecated, see https://github.com/ilastik/lazyflow/pull/250

* replaced all list style slot declarations with _fancy syntax_