### PR TITLE
Quickfix: CircleCI build: point to correct activate script

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -46,6 +46,6 @@ dependencies:
 test:
   override:
     - >
-      source ${TEST_ENV_PREFIX}/bin/activate ${TEST_ENV_NAME} &&
+      source ${CONDA_ROOT}/bin/activate ${TEST_ENV_NAME} &&
       cd ${TEST_ENV_PREFIX}/ilastik-meta/volumina/tests && 
       ./run-each-until-fail.sh


### PR DESCRIPTION
Seems like the conda guys have restructured the folders a bit.