### PR TITLE
safely retrieve original shape

### DIFF
--- a/volumina/widgets/slotMetaInfoDisplayWidget.py
+++ b/volumina/widgets/slotMetaInfoDisplayWidget.py
@@ -45,7 +45,7 @@ class SlotMetaInfoDisplayWidget(QWidget):
     
     def _refresh(self, *args):
         if self._slot.ready():
-            shape = tuple( self._slot.meta.original_shape )
+            shape = tuple( self._slot.meta.getOriginalShape() )
             axes = "".join( self._slot.meta.getOriginalAxisKeys() )
             dtype = self._slot.meta.dtype.__name__
         else:


### PR DESCRIPTION
This is the second PR in the quest to fix the label-import (currently it's broken).
Needs: https://github.com/ilastik/lazyflow/pull/280

Just makes sure that the `SlotMetaInfoWidget` works, even if there has not been any `OpReorderAxes` in the chain, which is the case when importing labels.