### PR TITLE
Fix getMainWindowBehaviour. Get the first biggest window

### DIFF
--- a/volumina/utility/getMainWindow.py
+++ b/volumina/utility/getMainWindow.py
@@ -24,5 +24,14 @@ def getMainWindow():
 
     # Now return the biggest widget we found.
     sizes = [w.width() * w.height() for w in top_level_widgets]
-    biggest_widget = max(list(zip(sizes, top_level_widgets)))[1]
-    return biggest_widget
+
+    max_area = 0
+    main_widget = None
+
+    for w in top_level_widgets:
+        area = w.width() * w.height()
+        if area > max_area:
+            max_area = area
+            main_widget = w
+
+    return main_widget

--- a/volumina/utility/getMainWindow.py
+++ b/volumina/utility/getMainWindow.py
@@ -1,6 +1,6 @@
 from PyQt5.QtWidgets import QApplication, QWidget, QMainWindow
 
-def getMainWindow():
+def getMainWindow() -> QMainWindow:
     """
     Attempt to return the main window for the app.
     There's no guaranteed way to find *the* main window, 
@@ -15,8 +15,8 @@ def getMainWindow():
 
     if not top_level_widgets:
         # Couldn't find any
-        return None
-    
+        raise Exception('Failed to determine main widget')
+
     # We prefer QMainWindow instances.  If we have any, drop all the other widgets.
     main_windows = [w for w in top_level_widgets if isinstance(w, QMainWindow)]
     if main_windows:


### PR DESCRIPTION
ShortcutManager relies on function getMainWindow to detect to which window attach shortcut listener.
So in our case, we had two non QMainWindow widgets with the same size which lead to a crash.