### PR TITLE
Refactor export helper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,6 @@ repos:
     rev: stable
     hooks:
     - id: black
-language_version: python3.6
+    args:
+    - --max-line-length=120
+language_version: python3.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,6 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: stable
-    hooks:
-    - id: black
-    args:
-    - --max-line-length=120
-language_version: python3.7
+- repo: https://github.com/ambv/black
+  rev: stable
+  hooks:
+  - id: black
+    language_version: python3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,4 +55,4 @@ script:
   - cd ${TEST_ENV_PREFIX}/ilastik-meta/volumina 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run pytest --capture=no --cov=volumina; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pytest --capture=no --cov=volumina; fi
-  - cd $TRAVIS_BUILD_DIR && git diff --name-only --diff-filter=AM master.. | grep ".*\.py" | xargs black --check --line-length=120
+  - cd $TRAVIS_BUILD_DIR && git diff --name-only --diff-filter=AM master.. | grep ".*\.py" | xargs black --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 120
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+)/
+'''

--- a/volumina/widgets/exportHelper.py
+++ b/volumina/widgets/exportHelper.py
@@ -66,7 +66,9 @@ def _get_export_slots(layer: Layer):
         RuntimeError: will be raised if the is no dataSource that has the "dataSlot" attribute, aka
           that is a lazyflow dataSource (slot)
     """
-    sourceTags = [hasattr(l, "dataSlot") for l in layer.datasources]
+    sourceTags = [
+        hasattr(l, "dataSlot") and l.dataSlot is not None for l in layer.datasources
+    ]
     if not any(sourceTags):
         raise RuntimeError(
             "can not export from a non-lazyflow data source (layer=%r, datasource=%r)"

--- a/volumina/widgets/exportHelper.py
+++ b/volumina/widgets/exportHelper.py
@@ -19,11 +19,12 @@ from __future__ import absolute_import
 # See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
 # GNU Lesser General Public License version 2.1 and 3 respectively.
 # This information is also available on the ilastik web site at:
-# 		   http://ilastik.org/license/
+#          http://ilastik.org/license/
 ###############################################################################
 # Python
 import os
 from functools import partial
+import typing
 
 # Qt
 from PyQt5.QtCore import pyqtSignal, QObject
@@ -35,9 +36,10 @@ from .multiStepProgressDialog import MultiStepProgressDialog
 
 import logging
 
-logger = logging.getLogger(__name__)
 from volumina.utility import log_exception, PreferencesManager
+from volumina.layer import Layer
 
+logger = logging.getLogger(__name__)
 ###
 ### lazyflow
 ###
@@ -51,46 +53,80 @@ except ImportError as e:
     _has_lazyflow = False
 
 
-def get_settings_and_export_layer(layer, parent_widget=None):
+def _get_export_slots(layer: Layer):
+    """Returns export slots for layer
+
+    Args:
+        layer (Layer): Volumina Layer, its datasources will be checked for "dataSlot" member.
+
+    Returns:
+        List of slots that can be exported from layer
+
+    Raises:
+        RuntimeError: will be raised if the is no dataSource that has the "dataSlot" attribute, aka
+          that is a lazyflow dataSource (slot)
     """
-    Prompt the user for layer export settings, and perform the layer export.
-    """
-    sourceTags = [True for l in layer.datasources]
-    for i, source in enumerate(layer.datasources):
-        if not hasattr(source, "dataSlot"):
-            sourceTags[i] = False
+    sourceTags = [hasattr(l, "dataSlot") for l in layer.datasources]
     if not any(sourceTags):
         raise RuntimeError(
             "can not export from a non-lazyflow data source (layer=%r, datasource=%r)"
             % (type(layer), type(layer.datasources[0]))
         )
+    return [
+        slot.dataSlot
+        for (slot, isSlot) in zip(layer.datasources, sourceTags)
+        if isSlot is True
+    ]
 
-    if not _has_lazyflow:
-        raise RuntimeError("lazyflow not installed")
+
+def _get_stacked_data_sources(layer: Layer):
     import lazyflow
 
-    dataSlots = [slot.dataSlot for (slot, isSlot) in zip(layer.datasources, sourceTags) if isSlot is True]
+    dataSlots = _get_export_slots(layer)
 
-    opStackChannels = lazyflow.operators.OpMultiArrayStacker(dataSlots[0].getRealOperator().parent)
+    opStackChannels = lazyflow.operators.OpMultiArrayStacker(
+        dataSlots[0].getRealOperator().parent
+    )
     for slot in dataSlots:
-        assert isinstance(slot, lazyflow.graph.Slot), "slot is of type %r" % (type(slot))
-        assert isinstance(slot.getRealOperator(), lazyflow.graph.Operator), "slot's operator is of type %r" % (
-            type(slot.getRealOperator())
+        assert isinstance(slot, lazyflow.graph.Slot), "slot is of type %r" % (
+            type(slot)
         )
+        assert isinstance(
+            slot.getRealOperator(), lazyflow.graph.Operator
+        ), "slot's operator is of type %r" % (type(slot.getRealOperator()))
     opStackChannels.AxisFlag.setValue("c")
     opStackChannels.Images.resize(len(dataSlots))
     for i, islot in enumerate(opStackChannels.Images):
         islot.connect(dataSlots[i])
 
-    export_dir = PreferencesManager().get("layer", "export-dir", default=os.path.expanduser("~"))
+    return opStackChannels
 
-    # Create an operator to do the work
+
+def get_export_operator(layer: Layer):
     from lazyflow.operators.ioOperators import OpFormattedDataExport
 
+    opStackChannels = _get_stacked_data_sources(layer)
+    # Create an operator to do the work
+
     opExport = OpFormattedDataExport(parent=opStackChannels.parent)
-    opExport.OutputFilenameFormat.setValue(os.path.join(export_dir, layer.name))
     opExport.Input.connect(opStackChannels.Output)
     opExport.TransactionSlot.setValue(True)
+
+    return opExport
+
+
+def get_settings_and_export_layer(layer: Layer, parent_widget=None):
+    """
+    Prompt the user for layer export settings, and perform the layer export.
+    """
+    if not _has_lazyflow:
+        raise RuntimeError("lazyflow not installed")
+    opExport = get_export_operator(layer)
+
+    export_dir = PreferencesManager().get(
+        "layer", "export-dir", default=os.path.expanduser("~")
+    )
+    opExport.OutputFilenameFormat.setValue(os.path.join(export_dir, layer.name))
 
     # Use this dialog to populate the operator's slot settings
     settingsDlg = DataExportOptionsDlg(parent_widget, opExport)
@@ -146,7 +182,9 @@ class ExportHelper(QObject):
         def _onFail(exc, exc_info):
             log_exception(logger, "Failed to export layer.", exc_info=exc_info)
             msg = "Failed to export layer due to the following error:\n{}".format(exc)
-            self._forwardingSignal.emit(partial(QMessageBox.critical, self.parent(), "Export Failed", msg))
+            self._forwardingSignal.emit(
+                partial(QMessageBox.critical, self.parent(), "Export Failed", msg)
+            )
             self._forwardingSignal.emit(progressDlg.setFailed)
 
         # Use a request to execute in the background

--- a/volumina/widgets/layercontextmenu.py
+++ b/volumina/widgets/layercontextmenu.py
@@ -27,13 +27,25 @@ from functools import partial
 
 # Qt
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QMenu, QAction, QDialog, QHBoxLayout, QTableWidget, QSizePolicy, QTableWidgetItem
+from PyQt5.QtWidgets import (
+    QMenu,
+    QAction,
+    QDialog,
+    QHBoxLayout,
+    QTableWidget,
+    QSizePolicy,
+    QTableWidgetItem,
+)
 from PyQt5.QtGui import QColor
 
 # volumina
-from volumina.layer import ColortableLayer, GrayscaleLayer, RGBALayer, ClickableColortableLayer
+from volumina.layer import (
+    ColortableLayer,
+    GrayscaleLayer,
+    RGBALayer,
+    ClickableColortableLayer,
+)
 from .layerDialog import GrayscaleLayerDialog, RGBALayerDialog
-from .exportHelper import get_settings_and_export_layer
 
 # ===----------------------------------------------------------------------------------------------------------------===
 
@@ -44,6 +56,7 @@ try:
     import lazyflow
 
     _has_lazyflow = True
+    from .exportHelper import get_settings_and_export_layer
 except ImportError as e:
     _has_lazyflow = False
 
@@ -104,7 +117,9 @@ def _add_actions(layer, menu):
         _add_actions_grayscalelayer(layer, menu)
     elif isinstance(layer, RGBALayer):
         _add_actions_rgbalayer(layer, menu)
-    elif isinstance(layer, ColortableLayer) or isinstance(layer, ClickableColortableLayer):
+    elif isinstance(layer, ColortableLayer) or isinstance(
+        layer, ClickableColortableLayer
+    ):
         _add_actions_colortablelayer(layer, menu)
 
 

--- a/volumina/widgets/layercontextmenu.py
+++ b/volumina/widgets/layercontextmenu.py
@@ -27,24 +27,11 @@ from functools import partial
 
 # Qt
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (
-    QMenu,
-    QAction,
-    QDialog,
-    QHBoxLayout,
-    QTableWidget,
-    QSizePolicy,
-    QTableWidgetItem,
-)
+from PyQt5.QtWidgets import QMenu, QAction, QDialog, QHBoxLayout, QTableWidget, QSizePolicy, QTableWidgetItem
 from PyQt5.QtGui import QColor
 
 # volumina
-from volumina.layer import (
-    ColortableLayer,
-    GrayscaleLayer,
-    RGBALayer,
-    ClickableColortableLayer,
-)
+from volumina.layer import ColortableLayer, GrayscaleLayer, RGBALayer, ClickableColortableLayer
 from .layerDialog import GrayscaleLayerDialog, RGBALayerDialog
 
 # ===----------------------------------------------------------------------------------------------------------------===
@@ -56,7 +43,7 @@ try:
     import lazyflow
 
     _has_lazyflow = True
-    from .exportHelper import get_settings_and_export_layer
+    from .exportHelper import prompt_export_settings_and_export_layer
 except ImportError as e:
     _has_lazyflow = False
 
@@ -117,9 +104,7 @@ def _add_actions(layer, menu):
         _add_actions_grayscalelayer(layer, menu)
     elif isinstance(layer, RGBALayer):
         _add_actions_rgbalayer(layer, menu)
-    elif isinstance(layer, ColortableLayer) or isinstance(
-        layer, ClickableColortableLayer
-    ):
+    elif isinstance(layer, (ColortableLayer, ClickableColortableLayer)):
         _add_actions_colortablelayer(layer, menu)
 
 
@@ -142,7 +127,7 @@ def layercontextmenu(layer, pos, parent=None):
     if _has_lazyflow:
         export = QAction("Export...", menu)
         export.setStatusTip("Export Layer...")
-        export.triggered.connect(partial(get_settings_and_export_layer, layer, menu))
+        export.triggered.connect(partial(prompt_export_settings_and_export_layer, layer, menu))
         menu.addAction(export)
 
     menu.addSeparator()


### PR DESCRIPTION
Motivation: I wanted to export some layer from the layerstack programmatically
in an ilastik gui test and not duplicate the whole functionality from volumina.

As it was implemented in volumina it was not possible to re-use the code in a
non-interactive way.

* I factored out some functions, hoping the code would be easier to read, and also in order to expose the `get_export_operator(layer)` function.
*  rename: `get_settings_and_export_layer` -> `prompt_export_settings_and_export_layer`
* Also properly configured black via `pyproject.toml` ([as they recommend in their docs](https://github.com/python/black#version-control-integration))