### PR TITLE
added MockGLView to replace GLView if OpenGL < 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       CONDA_ROOT: /home/ubuntu/miniconda
       TEST_ENV_NAME: test-env
       TEST_ENV_PREFIX: /home/ubuntu/miniconda/envs/test-env
-      VIEWPORT_USE_OPENGL: 0
+      VOLUMINA_SHOW_3D_WIDGET: 0
     docker:
     - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
       command: /sbin/init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       CONDA_ROOT: /home/ubuntu/miniconda
       TEST_ENV_NAME: test-env
       TEST_ENV_PREFIX: /home/ubuntu/miniconda/envs/test-env
+      VIEWPORT_USE_OPENGL: 0
     docker:
     - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
       command: /sbin/init

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,6 @@ script:
   - cd ${TEST_ENV_PREFIX}/ilastik-meta/volumina 
   # added -s "-screen 0 1024x768x16", to make overview3d_test.py pass,
   # failure was related to xvfb-run on travis running the screen per default on 8 bit.
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then VIEWPORT_USE_OPENGL=0 xvfb-run -s "-screen 0 1024x768x16" pytest --capture=no --cov=volumina; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then VOLUMINA_SHOW_3D_WIDGET=0 xvfb-run -s "-screen 0 1024x768x16" pytest --capture=no --cov=volumina; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pytest --capture=no --cov=volumina; fi
   - cd $TRAVIS_BUILD_DIR && git diff --name-only --diff-filter=AM master.. | grep ".*\.py" | xargs black --check

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ script:
   - echo `which python`
   - echo `which pytest`
   - cd ${TEST_ENV_PREFIX}/ilastik-meta/volumina 
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run pytest --capture=no --cov=volumina; fi
+  # added -s "-screen 0 1024x768x16", to make overview3d_test.py pass,
+  # failure was related to xvfb-run on travis running the screen per default on 8 bit.
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then VIEWPORT_USE_OPENGL=0 xvfb-run -s "-screen 0 1024x768x16" pytest --capture=no --cov=volumina; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pytest --capture=no --cov=volumina; fi
   - cd $TRAVIS_BUILD_DIR && git diff --name-only --diff-filter=AM master.. | grep ".*\.py" | xargs black --check

--- a/tests/glview_test.py
+++ b/tests/glview_test.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch, PropertyMock
+import importlib
+
+
+import volumina.view3d.glview as glview
+
+
+def test_import_gl_enabled():
+    with patch("volumina.config.Config.use_opengl_viewport", new_callable=PropertyMock(return_value=True)):
+        importlib.reload(glview)
+        assert glview.GLView == glview.GLViewReal
+
+
+def test_import_gl_disabled():
+    with patch("volumina.config.Config.use_opengl_viewport", new_callable=PropertyMock(return_value=False)):
+        importlib.reload(glview)
+        assert glview.GLView == glview.GLViewMock

--- a/tests/glview_test.py
+++ b/tests/glview_test.py
@@ -6,12 +6,12 @@ import volumina.view3d.glview as glview
 
 
 def test_import_gl_enabled():
-    with patch("volumina.config.Config.use_opengl_viewport", new_callable=PropertyMock(return_value=True)):
+    with patch("volumina.config.Config.show_3d_widget", new_callable=PropertyMock(return_value=True)):
         importlib.reload(glview)
         assert glview.GLView == glview.GLViewReal
 
 
 def test_import_gl_disabled():
-    with patch("volumina.config.Config.use_opengl_viewport", new_callable=PropertyMock(return_value=False)):
+    with patch("volumina.config.Config.show_3d_widget", new_callable=PropertyMock(return_value=False)):
         importlib.reload(glview)
         assert glview.GLView == glview.GLViewMock

--- a/volumina/config.py
+++ b/volumina/config.py
@@ -28,6 +28,9 @@ import os
 default_config = """
 [pixelpipeline]
 verbose: false
+
+[viewport]
+use_opengl: true
 """
 
 _cfg = configparser.ConfigParser()
@@ -40,10 +43,25 @@ if os.path.exists(userConfig):
 class Config:
     def __init__(self, cfg):
         self._cfg = cfg
+        self._env = os.environ
 
     @property
     def verbose_pixelpipeline(self):
-        return self._cfg.getboolean("pixelpipeline", "verbose")
+        return self._get_boolean("pixelpipeline", "verbose")
+
+    @property
+    def use_opengl_viewport(self):
+        return self._get_boolean("viewport", "use_opengl")
+
+    def _get_boolean(self, section: str, option: str) -> bool:
+        val = self._env.get(f"{section.upper()}_{option.upper()}")
+        if val is not None:
+            try:
+                return bool(int(val))
+            except ValueError:
+                pass
+
+        return self._cfg.getboolean(section, option)
 
 
 CONFIG = Config(_cfg)

--- a/volumina/config.py
+++ b/volumina/config.py
@@ -53,13 +53,13 @@ class Config:
 
     def _get_boolean(self, section: str, option: str) -> bool:
         val = self._env.get(f"{section.upper()}_{option.upper()}")
-        if val is not None:
-            try:
-                return bool(int(val))
-            except ValueError:
-                pass
+        if val is None:
+            return self._cfg.getboolean(section, option)
 
-        return self._cfg.getboolean(section, option)
+        try:
+            return bool(int(val))
+        except ValueError as e:
+            raise ValueError(f"environment variable {val!r} is not a boolean") from e
 
 
 CONFIG = Config(_cfg)

--- a/volumina/config.py
+++ b/volumina/config.py
@@ -26,11 +26,9 @@ import configparser
 import os
 
 default_config = """
-[pixelpipeline]
-verbose: false
-
-[viewport]
-use_opengl: true
+[volumina]
+pixelpipeline_verbose: false
+show_3d_widget: true
 """
 
 _cfg = configparser.ConfigParser()
@@ -47,11 +45,11 @@ class Config:
 
     @property
     def verbose_pixelpipeline(self):
-        return self._get_boolean("pixelpipeline", "verbose")
+        return self._get_boolean("volumina", "pixelpipeline_verbose")
 
     @property
-    def use_opengl_viewport(self):
-        return self._get_boolean("viewport", "use_opengl")
+    def show_3d_widget(self):
+        return self._get_boolean("volumina", "show_3d_widget")
 
     def _get_boolean(self, section: str, option: str) -> bool:
         val = self._env.get(f"{section.upper()}_{option.upper()}")

--- a/volumina/view3d/glview.py
+++ b/volumina/view3d/glview.py
@@ -2,13 +2,19 @@ from pyqtgraph.opengl import GLViewWidget
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QVector4D
+from PyQt5.QtWidgets import QLabel
 
 from volumina.view3d.slicingplanes import SlicingPlanes
 from volumina.view3d.axessymbols import AxesSymbols
 from volumina.utility import PreferencesManager
+import volumina.config
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 
-class GLView(GLViewWidget):
+class GLViewReal(GLViewWidget):
     """
     The actual 3D view seen in the bottom right corner of ilastik.
 
@@ -190,3 +196,46 @@ class GLView(GLViewWidget):
         """
         self._slice_planes.release()
         return GLViewWidget.mousePressEvent(self, event)
+
+
+class GLViewMock(QLabel):
+    slice_changed = pyqtSignal()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setText("3D widget disabled via $HOME/.voluminarc or environment variable\n" "FEATURES_USE_OPENGL_WIDGET.")
+
+    def add_mesh(self, name, mesh=None):
+        pass
+
+    def remove_mesh(self, name):
+        pass
+
+    def is_cached(self, name):
+        return False
+
+    def invalidate_cache(self, name):
+        pass
+
+    @property
+    def visible_meshes(self):
+        return []
+
+    @property
+    def slice(self):
+        return (0, 0, 0)
+
+    @slice.setter
+    def slice(self, slice_):
+        pass
+
+    def set_shape(self, shape):
+        pass
+
+    shape = property(fset=set_shape)
+
+    def toggle_slice(self, axis, visible):
+        pass
+
+
+GLView = volumina.config.CONFIG.use_opengl_viewport and GLViewReal or GLViewMock

--- a/volumina/view3d/glview.py
+++ b/volumina/view3d/glview.py
@@ -203,7 +203,9 @@ class GLViewMock(QLabel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.setText("3D widget disabled via $HOME/.voluminarc or environment variable\n" "FEATURES_USE_OPENGL_WIDGET.")
+        self.setText(
+            "3D widget disabled via $HOME/.voluminarc or environment variable" "<pre>FEATURES_USE_OPENGL_WIDGET</pre>"
+        )
 
     def add_mesh(self, name, mesh=None):
         pass
@@ -238,4 +240,7 @@ class GLViewMock(QLabel):
         pass
 
 
-GLView = volumina.config.CONFIG.show_3d_widget and GLViewReal or GLViewMock
+if volumina.config.Config.show_3d_widget:
+    GLView = GLViewReal
+else:
+    GLView = GLViewMock

--- a/volumina/view3d/glview.py
+++ b/volumina/view3d/glview.py
@@ -238,4 +238,4 @@ class GLViewMock(QLabel):
         pass
 
 
-GLView = volumina.config.CONFIG.use_opengl_viewport and GLViewReal or GLViewMock
+GLView = volumina.config.CONFIG.show_3d_widget and GLViewReal or GLViewMock


### PR DESCRIPTION
ilastik carving gui tests on Windows CI (appveyor) failed because
the 3D widget would raise an error when drawing 3D stuff, as the
provided GL version (1.0, 1.1) is not enough.

* Added a check to GLView, to get the current OpenGL version
* Added a MockGLView that is replaced in Overview3D in case version
  is not sufficient
* Config/environment variables:
  * Config values can now be overriden via environment variables
  * `VOLUMINA_VERBOSE_PIXELPIPELINE=1`, `VOLUMINA_SHOW_3D_WIDGET=0`

Related to  https://github.com/ilastik/ilastik/issues/1297 https://github.com/ilastik/ilastik/issues/1885

Todo:

- [x] add test :)
