### PR TITLE
fix properly use config to configure 3D view

### DIFF
--- a/tests/glview_test.py
+++ b/tests/glview_test.py
@@ -6,12 +6,12 @@ import volumina.view3d.glview as glview
 
 
 def test_import_gl_enabled():
-    with patch("volumina.config.Config.show_3d_widget", new_callable=PropertyMock(return_value=True)):
+    with patch("volumina.config._Config.show_3d_widget", new=PropertyMock(return_value=True)):
         importlib.reload(glview)
         assert glview.GLView == glview.GLViewReal
 
 
 def test_import_gl_disabled():
-    with patch("volumina.config.Config.show_3d_widget", new_callable=PropertyMock(return_value=False)):
+    with patch("volumina.config._Config.show_3d_widget", new=PropertyMock(return_value=False)):
         importlib.reload(glview)
         assert glview.GLView == glview.GLViewMock

--- a/volumina/config.py
+++ b/volumina/config.py
@@ -19,9 +19,6 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from future import standard_library
-
-standard_library.install_aliases()
 import configparser
 import os
 
@@ -38,7 +35,7 @@ if os.path.exists(userConfig):
     _cfg.read(userConfig)
 
 
-class Config:
+class _Config:
     def __init__(self, cfg):
         self._cfg = cfg
         self._env = os.environ
@@ -62,4 +59,4 @@ class Config:
             raise ValueError(f"environment variable {val!r} is not a boolean") from e
 
 
-CONFIG = Config(_cfg)
+CONFIG = _Config(_cfg)

--- a/volumina/view3d/glview.py
+++ b/volumina/view3d/glview.py
@@ -204,7 +204,7 @@ class GLViewMock(QLabel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setText(
-            "3D widget disabled via $HOME/.voluminarc or environment variable" "<pre>FEATURES_USE_OPENGL_WIDGET</pre>"
+            "3D widget disabled via $HOME/.voluminarc or environment variable" "<pre>VOLUMINA_SHOW_3D_WIDGET</pre>"
         )
 
     def add_mesh(self, name, mesh=None):
@@ -240,7 +240,7 @@ class GLViewMock(QLabel):
         pass
 
 
-if volumina.config.Config.show_3d_widget:
+if volumina.config.CONFIG.show_3d_widget:
     GLView = GLViewReal
 else:
     GLView = GLViewMock

--- a/volumina/view3d/glview.py
+++ b/volumina/view3d/glview.py
@@ -204,7 +204,10 @@ class GLViewMock(QLabel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.setText(
-            "3D widget disabled via $HOME/.voluminarc or environment variable" "<pre>VOLUMINA_SHOW_3D_WIDGET</pre>"
+            "3D widget disabled via $HOME/.voluminarc or environment variable"
+            "<pre>VOLUMINA_SHOW_3D_WIDGET</pre>\n\n"
+            "Example .voluminarc:\n"
+            "<pre>[volumina]\nshow_3d_widget: true\n</pre>"
         )
 
     def add_mesh(self, name, mesh=None):


### PR DESCRIPTION
Related to #239 #240 

there was a bug where `volumina.config.Config` was directly called
and not instantiated. Apparently the `Config.show_3d_widget` always
returns a property-object that is always interpreted as `True`.

* Use proper `volumina.config.CONFIG` object (uppercase).
* Hide `_Config` class.

