### PR TITLE
Reduce tiling logs from errors to debugs

### DIFF
--- a/volumina/tiling.py
+++ b/volumina/tiling.py
@@ -658,7 +658,7 @@ class TileProvider(QObject):
                     # Settings changes can cause 'slot not ready' errors during graph setup.
                     # Those errors are not really a problem, but we don't want to hide them from developers
                     # So, we show the exception (in the log), but we don't kill the thread.
-                    logger.exception("Failed to create layer tile request")
+                    logger.debug("Failed to create layer tile request", exc_info=True)
                     continue
 
                 timestamp = time.time()
@@ -801,7 +801,7 @@ class TileProvider(QObject):
                 if stack_id == self._current_stack_id and cache is self._cache:
                     self.sceneRectChanged.emit(tile_rect)
         except BaseException:
-            logger.exception("Failed to fetch layer tile")
+            logger.debug("Failed to fetch layer tile", exc_info=True)
 
     def _onLayerDirty(self, dirtyImgSrc, dataRect):
         """


### PR DESCRIPTION
those messages were previously swallowed by `sys.excepthook` for some reason.
When these were changed to `logger.error` they were actually displayed.

https://github.com/ilastik/volumina/commit/2b09109b478a7f30787d9cecbad01ce82812a671

We want to restore the original behavior of hiding these. Hence, a lower log-
level should be used.