### PR TITLE
Do not remove missing layers in LayerDelegate

### DIFF
--- a/volumina/widgets/layerwidget.py
+++ b/volumina/widgets/layerwidget.py
@@ -376,12 +376,12 @@ class LayerDelegate(QStyledItemDelegate):
         else:
             QStyledItemDelegate.setModelData(self, editor, model, index)
 
-    def handleRemovedRows(self, parent, start, end):
-        for row in range(start, end):
-            itemData = self._listModel.itemData(self._listModel.index(row))
-            layer = itemData[Qt.EditRole]
-            del self._editors[layer]
-            assert isinstance(layer, Layer)
+    def handleRemovedRows(self, _parent, first, last):
+        for row in range(first, last + 1):
+            layer = self._listModel.data(self._listModel.index(row), Qt.EditRole)
+            if layer is not None:
+                assert isinstance(layer, Layer)
+                del self._editors[layer]
 
 
 class LayerWidget(QListView):


### PR DESCRIPTION
For some reason, `LayerDelegate.handleRemovedRows` could be called when
the model's data does not contain an item for the `EditRole`.

Also, `QAbstractItemModel.rowsAboutToBeRemoved` signal has an inclusive
right boundary, so parameters have been renamed to `first` and `last`,
which is consistent with the [Qt documentation](https://doc.qt.io/qt-5/qabstractitemmodel.html#rowsAboutToBeRemoved).

Closes https://github.com/ilastik/ilastik/issues/1997.