### PR TITLE
Move special case for mouse events to HUD

### DIFF
--- a/volumina/brushingcontroller.py
+++ b/volumina/brushingcontroller.py
@@ -26,6 +26,7 @@ from PyQt5.QtCore import pyqtSignal, QObject, QEvent, QPointF, Qt, QTimer
 from PyQt5.QtGui import QPen, QBrush, QMouseEvent
 from PyQt5.QtWidgets import QApplication, QGraphicsLineItem
 
+from volumina.eventswitch import InterpreterABC
 from .navigationController import NavigationInterpreter
 
 # *******************************************************************************
@@ -55,7 +56,7 @@ class CrosshairController(QObject):
 # *******************************************************************************
 
 
-class BrushingInterpreter(QObject):
+class BrushingInterpreter(QObject, InterpreterABC):
     # states
     FINAL = 0
     DEFAULT_MODE = 1

--- a/volumina/eventswitch.py
+++ b/volumina/eventswitch.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ###############################################################################
 #   volumina: volume slicing and editing library
 #
@@ -21,44 +19,26 @@ from __future__ import absolute_import
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from builtins import object
-from PyQt5.QtCore import QObject, Qt, QEvent
+
+from PyQt5.QtCore import QObject, QEvent
 from PyQt5.QtGui import QMouseEvent
 
-from abc import ABCMeta, abstractmethod
-
-from .imageView2D import ImageView2D
-from future.utils import with_metaclass
+from volumina.imageView2D import ImageView2D
+from volumina.utility.qabc import QABC, abstractmethod
 
 
-def _has_attribute(cls, attr):
-    return True if any(attr in B.__dict__ for B in cls.__mro__) else False
-
-
-def _has_attributes(cls, attrs):
-    return True if all(_has_attribute(cls, a) for a in attrs) else False
-
-
-class InterpreterABC(with_metaclass(ABCMeta, object)):
+class InterpreterABC(QABC):
     @abstractmethod
-    def start(self):
+    def start(self) -> None:
         """Start the interpretation of an event stream."""
 
     @abstractmethod
-    def stop(self):
+    def stop(self) -> None:
         """Stop the interpretation of the event stream."""
 
     @abstractmethod
-    def eventFilter(self, watched, event):
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
         """Necessary to act as a Qt event filter. """
-
-    @classmethod
-    def __subclasshook__(cls, C):
-        if cls is InterpreterABC:
-            if _has_attributes(C, ["start", "stop", "eventFilter"]):
-                return True
-            return False
-        return NotImplemented
 
 
 class EventSwitch(QObject):

--- a/volumina/interpreter.py
+++ b/volumina/interpreter.py
@@ -19,10 +19,13 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
+
 from PyQt5.QtCore import QObject, pyqtSignal, QEvent, Qt, QPoint
 
+from volumina.eventswitch import InterpreterABC
 
-class ClickReportingInterpreter(QObject):
+
+class ClickReportingInterpreter(QObject, InterpreterABC):
     rightClickReceived = pyqtSignal(object, QPoint)  # list of indexes, global window coordinate of click
     leftClickReceived = pyqtSignal(object, QPoint)  # ditto
     toolTipReceived = pyqtSignal(object, QPoint)
@@ -67,7 +70,7 @@ class ClickReportingInterpreter(QObject):
         self.baseInterpret.updateCursorPosition(*args, **kwargs)
 
 
-class ClickInterpreter(QObject):
+class ClickInterpreter(QObject, InterpreterABC):
     """Intercepts mouse clicks (right clicks by default) and double
        click events on a layer and calls a given functor with the
        clicked position.

--- a/volumina/navigationController.py
+++ b/volumina/navigationController.py
@@ -182,7 +182,7 @@ class NavigationInterpreter(QObject, InterpreterABC):
             return False
 
         self.updateCursorPosition(imageview, event)
-        return True
+        return False
 
     def updateCursorPosition(self, imageview, event):
         """Update the position model's cursor position according to the given event position."""

--- a/volumina/navigationController.py
+++ b/volumina/navigationController.py
@@ -44,7 +44,7 @@ def posView2D(pos3d, axis):
 # *******************************************************************************
 
 
-class NavigationInterpreter(QObject):
+class NavigationInterpreter(QObject, InterpreterABC):
     # states
     FINAL = 0
     DEFAULT_MODE = 1
@@ -256,8 +256,6 @@ class NavigationInterpreter(QObject):
         imageview._panning()
         imageview._lastPanPoint = event.pos()
 
-
-assert issubclass(NavigationInterpreter, InterpreterABC)
 
 # *******************************************************************************
 # N a v i g a t i o n C o n t r o l e r                                        *

--- a/volumina/skeletons/skeletonInterpreter.py
+++ b/volumina/skeletons/skeletonInterpreter.py
@@ -25,10 +25,11 @@ from builtins import range
 from PyQt5.QtCore import QObject, QEvent, Qt
 import copy
 
+from volumina.eventswitch import InterpreterABC
 from volumina.skeletons.skeletonsLayer3D import SkeletonsLayer3D
 
 
-class SkeletonInterpreter(QObject):
+class SkeletonInterpreter(QObject, InterpreterABC):
     def __init__(self, editor, skeletons, parent=None):
         QObject.__init__(self, parent=parent)
         self.baseInterpret = editor.navInterpret

--- a/volumina/sliceSelectorHud.py
+++ b/volumina/sliceSelectorHud.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 ###############################################################################
 #   volumina: volume slicing and editing library
 #
@@ -21,32 +19,29 @@ from __future__ import division
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from past.utils import old_div
+
 import os
 from functools import partial
 
-# PyQt
-from PyQt5.QtCore import pyqtSignal, Qt, QPointF, QSize
-from PyQt5.QtGui import QPen, QPainter, QPixmap, QColor, QFont, QPainterPath, QBrush, QTransform, QIcon
-
+import volumina
+from past.utils import old_div
+from PyQt5.QtCore import QCoreApplication, QEvent, QPointF, QSize, Qt, pyqtSignal
+from PyQt5.QtGui import QBrush, QColor, QFont, QIcon, QMouseEvent, QPainter, QPainterPath, QPen, QPixmap, QTransform
 from PyQt5.QtWidgets import (
-    QLabel,
-    QHBoxLayout,
-    QVBoxLayout,
     QAbstractSpinBox,
     QCheckBox,
-    QWidget,
     QFrame,
+    QHBoxLayout,
+    QLabel,
     QProgressBar,
     QSizePolicy,
     QSlider,
     QToolButton,
+    QVBoxLayout,
+    QWidget,
 )
-
-
-import volumina
-from volumina.widgets.delayedSpinBox import DelayedSpinBox
 from volumina.utility import ShortcutManager
+from volumina.widgets.delayedSpinBox import DelayedSpinBox
 
 TEMPLATE = "QSpinBox {{ color: {0}; font: bold; background-color: {1}; border:0;}}"
 
@@ -273,6 +268,15 @@ class ImageView2DHud(QWidget):
         self.layout.setSpacing(0)
 
         self.buttons = {}
+
+    def event(self, event: QEvent) -> bool:
+        # Pass a mouse event to QGraphicsView viewport first because HUD is overlayed on top of the QGraphicsView.
+        consumed = False
+        if isinstance(event, QMouseEvent):
+            consumed = QCoreApplication.sendEvent(self.parent().viewport(), event)
+        if not consumed:
+            consumed = super().event(event)
+        return consumed
 
     def _add_button(self, name, handler):
         button = LabelButtons(

--- a/volumina/thresholdingcontroller.py
+++ b/volumina/thresholdingcontroller.py
@@ -3,6 +3,8 @@ from __future__ import division
 from past.utils import old_div
 from PyQt5.QtCore import Qt, QEvent, QObject, QPoint
 import numpy as np
+
+from volumina.eventswitch import InterpreterABC
 from .navigationController import NavigationInterpreter, posView2D
 from volumina.layer import GrayscaleLayer
 
@@ -12,7 +14,7 @@ from volumina.layer import GrayscaleLayer
 # *******************************************************************************
 
 
-class ThresholdingInterpreter(QObject):
+class ThresholdingInterpreter(QObject, InterpreterABC):
     # states
     FINAL = 0
     DEFAULT_MODE = 1  # normal navigation functionality

--- a/volumina/volumeEditor.py
+++ b/volumina/volumeEditor.py
@@ -195,13 +195,13 @@ class VolumeEditor(QObject):
         ##
         ## interaction
         ##
-        # event switch
-        self.eventSwitch = EventSwitch(self.imageViews)
 
         # navigation control
-        v3d = self.view3d
-        self.navCtrl = NavigationController(self.imageViews, self.imagepumps, self.posModel, view3d=v3d)
+        self.navCtrl = NavigationController(self.imageViews, self.imagepumps, self.posModel, view3d=self.view3d)
         self.navInterpret = NavigationInterpreter(self.navCtrl)
+
+        # event switch
+        self.eventSwitch = EventSwitch(self.imageViews, self.navInterpret)
 
         # brushing control
         if crosshair:
@@ -214,8 +214,6 @@ class VolumeEditor(QObject):
 
         # thresholding control
         self.thresInterpreter = ThresholdingInterpreter(self.navCtrl, self.layerStack, self.posModel)
-        # initial interaction mode
-        self.eventSwitch.interpreter = self.navInterpret
 
         # By default, don't show cropping controls
         self.showCropLines(False)


### PR DESCRIPTION
Previously, EventSwtich installed itself as an event filter to both
ImageView2D (which is QGraphicsView) and it's viewport because a single
event filter should be able to catch all events (see https://stackoverflow.com/questions/2445997/qgraphicsview-and-eventfilter
for details). This made it hard to understand how events interact with
different event filters.

Another solution described in one of the anwsers in the link above is to
remove focus proxy from QGraphicsView. QAbstractScrollArea (superclass
of QGraphicsView) installs itself as a focus proxy to it's viewport
in order to be able to handle scrolling via keyboard. Since our
application doesn't need that, it is safe to remove the focus proxy and
simplify event handling.

However, HUD is currently displayed as a sibling of QGraphicsView
viewport, which causes problems when a user wants to do something with
a mouse in a HUD area that doesn't contain buttons, but has a usable
area underneath. We solve that problem by sending all mouse events from
HUD to the viewport of QGraphicsView.

Closes https://github.com/ilastik/ilastik/issues/2091.