### PR TITLE
fixes crash related to Overview3d with Python 3.7.4 on OSX

### DIFF
--- a/volumina/navigationController.py
+++ b/volumina/navigationController.py
@@ -372,7 +372,7 @@ class NavigationController(QObject):
 
         def maybeUpdateSlice(oldSlicing):
             if oldSlicing == self._model.slicingPos:
-                self._view3d.slice = self._model.slicingPos
+                self._view3d.set_slice(self._model.slicingPos)
 
         QTimer.singleShot(50, partial(maybeUpdateSlice, self._model.slicingPos))
 

--- a/volumina/view3d/overview3d.py
+++ b/volumina/view3d/overview3d.py
@@ -70,10 +70,7 @@ class Overview3D(QWidget):
         """
         self._view.shape = self._adjust_axes(*shape)
 
-    shape = property(fset=set_shape)
-
-    @property
-    def slice(self):
+    def get_slice(self):
         """
         Get the current slice from the 3d view.
 
@@ -81,8 +78,7 @@ class Overview3D(QWidget):
         """
         return self._adjust_axes(*self._view.slice)
 
-    @slice.setter
-    def slice(self, slice_):
+    def set_slice(self, slice_):
         """
         Set the current slice for the 3d view.
 
@@ -125,8 +121,7 @@ class Overview3D(QWidget):
         """
         return self._view.is_cached(name)
 
-    @property
-    def visible_objects(self):
+    def get_visible_objects(self):
         """
         Get the label of all currently visible objects in the 3d view.
 

--- a/volumina/view3d/volumeRendering.py
+++ b/volumina/view3d/volumeRendering.py
@@ -93,7 +93,7 @@ class RenderingManager(object):
 
         new_labels = set(numpy.unique(self._volume))
         new_names = set(filter(None, (self._mapping.get(label) for label in new_labels)))
-        old_names = self._overview_scene.visible_objects
+        old_names = self._overview_scene.get_visible_objects()
         for name in old_names - new_names:
             self._overview_scene.remove_object(name)
 

--- a/volumina/volumeEditor.py
+++ b/volumina/volumeEditor.py
@@ -140,7 +140,7 @@ class VolumeEditor(QObject):
 
         for i, v in enumerate(self.imageViews):
             v.sliceShape = self.posModel.sliceShape(axis=i)
-        self.view3d.shape = s[1:4]
+        self.view3d.set_shape(s[1:4])
 
     def lastImageViewFocus(self, axis):
         self._lastImageViewFocus = axis
@@ -285,7 +285,7 @@ class VolumeEditor(QObject):
         view3d = Overview3D(is_3d_widget_visible=is_3d_widget_visible)
 
         def onSliceDragged():
-            self.posModel.slicingPos = view3d.slice
+            self.posModel.slicingPos = view3d.get_slice()
 
         view3d.slice_changed.connect(onSliceDragged)
         return view3d


### PR DESCRIPTION
Since Python 3.7.4 an error bubbles up that has been ignored in previous Python versions.
The cause is `PyQt5` accessing all class attributes via `PyObject_GetAttr` during initialization of the Gui Widget. In our case, the class is not fully initalized by that time but class properties are still executed (via `PyObject_GetAttr`).

There are a couple of solutions to this problem ([related thread on riverbank mailinglist](https://www.riverbankcomputing.com/pipermail/pyqt/2019-August/042020.html)

 * this PR: properties removed in favor of get/set functions.
 * wait until PyQt5 5.13.1 is available on conda-forge -> the issue is fixed there
 * switch to PySide2 for the whole of ilastik. Those are the official Qt bindings.