### PR TITLE
mnt: h5py deprecation of dataset.value -> dataset[()]

### DIFF
--- a/tests/colortable_contextmenu_manual.py
+++ b/tests/colortable_contextmenu_manual.py
@@ -45,7 +45,7 @@ gname = args[0][x + 4 :]
 
 # load data
 f = h5py.File(fname, "r")
-raw = f[gname].value
+raw = f[gname][()]
 assert raw.ndim == 3
 assert raw.dtype == numpy.uint8
 f.close()

--- a/tests/direct_layer_manual.py
+++ b/tests/direct_layer_manual.py
@@ -46,7 +46,7 @@ gname = args[0][x + 4 :]
 
 # load data
 f = h5py.File(fname, "r")
-raw = f[gname].value.squeeze()
+raw = f[gname][()].squeeze()
 assert raw.ndim == 3
 assert raw.dtype == numpy.uint8
 f.close()

--- a/tests/skeletons.py
+++ b/tests/skeletons.py
@@ -49,7 +49,7 @@ try:
     f = h5py.File(fname, "r")
 except:
     raise RuntimeError("Could not load '%s'" % fname)
-raw = f[gname].value.squeeze()
+raw = f[gname][()].squeeze()
 assert raw.ndim == 3
 assert raw.dtype == numpy.uint8
 f.close()


### PR DESCRIPTION
volumina analogon to https://github.com/ilastik/ilastik/pull/2216

accessing the `.value` member on h5py groups is deprecated.
Gets rid of
```
H5pyDeprecationWarning: dataset.value has been deprecated. Use dataset[()] instead.
```