### PR TITLE
Reduce number of smoothing rounds

### DIFF
--- a/volumina/view3d/meshgenerator.py
+++ b/volumina/view3d/meshgenerator.py
@@ -59,7 +59,7 @@ ShaderProgram(
 def labeling_to_mesh(labeling, labels):
 
     for label in labels:
-        vertices, normals, faces = march(where(labeling == label, 2, 0).astype(int).T, 4)
+        vertices, normals, faces = march(where(labeling == label, 2, 0).astype(int).T, 3)
         data = MeshData(vertices, faces)
         if normals is not None:
             data._vertexNormals = normals


### PR DESCRIPTION
Due to a bug (https://github.com/ilastik/marching_cubes/pull/23) in the marching cubes repo, smoothing rounds were off by one.
In order to retain consistent behavior we have to reduce the number of smoothing rounds.

(thanks to @stuarteberg for fixing it!)