### PR TITLE
Undo redo

### DIFF
--- a/examples/labeling.py
+++ b/examples/labeling.py
@@ -37,6 +37,6 @@ v.layerstack.append(label_layer)
 v.editor.setLabelSink(label_src)
 v.editor.setInteractionMode("brushing")
 
-v.setWindowTitle("streaming viewer")
+v.setWindowTitle("labeling")
 v.showMaximized()
 app.exec_()

--- a/tests/test_brushingcontroller.py
+++ b/tests/test_brushingcontroller.py
@@ -1,0 +1,58 @@
+from unittest import mock
+from volumina.brushingcontroller import DrawLabelCommand
+import numpy
+
+
+class TestDrawLabelCommand:
+    def test_redo_command(self):
+        sink = mock.Mock()
+        old_data = numpy.array([1, 1, 0, 0, 0])
+        labels = numpy.array([0, 2, 2, 0, 0], dtype="uint8")
+        slicing = slice(0, 5)
+
+        cmd = DrawLabelCommand(sink=sink, slicing=slicing, old_data=old_data, labels=labels)
+        cmd.redo()
+
+        expected_put_arr = numpy.array([1, 2, 2, 0, 0])
+
+        sink.put.assert_called_once()
+        assert sink.put.call_args[0][0] == slicing
+        actual_put_arr = sink.put.call_args[0][1]
+        numpy.testing.assert_array_equal(actual_put_arr, expected_put_arr)
+        assert actual_put_arr.dtype == labels.dtype
+
+    def test_undo_command_no_eraser_value_should_overwrite_with_old_data(self):
+        sink = mock.Mock()
+        sink.eraser_value = None
+
+        old_data = numpy.array([1, 1, 0, 0, 0])
+        labels = numpy.array([0, 2, 2, 0, 0], dtype="uint8")
+        slicing = slice(0, 5)
+
+        cmd = DrawLabelCommand(sink=sink, slicing=slicing, old_data=old_data, labels=labels)
+        cmd.undo()
+
+        sink.put.assert_called_once()
+        assert sink.put.call_args[0][0] == slicing
+        actual_put_arr = sink.put.call_args[0][1]
+        numpy.testing.assert_array_equal(actual_put_arr, old_data)
+        assert actual_put_arr.dtype == labels.dtype
+
+    def test_undo_command_with_eraser_value_overlays_old_data_with_eraser(self):
+        sink = mock.Mock()
+        sink.eraser_value = 100
+
+        old_data = numpy.array([1, 1, 0, 0, 0])
+        labels = numpy.array([0, 2, 2, 0, 0], dtype="uint8")
+        slicing = slice(0, 5)
+
+        cmd = DrawLabelCommand(sink=sink, slicing=slicing, old_data=old_data, labels=labels)
+        cmd.undo()
+
+        expected_put_arr = numpy.array([1, 1, 100, 0, 0])
+
+        sink.put.assert_called_once()
+        assert sink.put.call_args[0][0] == slicing
+        actual_put_arr = sink.put.call_args[0][1]
+        numpy.testing.assert_array_equal(actual_put_arr, sink.put.call_args[0][1], expected_put_arr)
+        assert actual_put_arr.dtype == labels.dtype

--- a/volumina/brushingcontroller.py
+++ b/volumina/brushingcontroller.py
@@ -21,10 +21,11 @@ from __future__ import absolute_import
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
+import numpy
 from functools import partial
 from PyQt5.QtCore import pyqtSignal, QObject, QEvent, QPointF, Qt, QTimer
 from PyQt5.QtGui import QPen, QBrush, QMouseEvent
-from PyQt5.QtWidgets import QApplication, QGraphicsLineItem
+from PyQt5.QtWidgets import QApplication, QGraphicsLineItem, QUndoStack, QUndoCommand
 
 from volumina.eventswitch import InterpreterABC
 from .navigationController import NavigationInterpreter
@@ -32,6 +33,28 @@ from .navigationController import NavigationInterpreter
 # *******************************************************************************
 # C r o s s h a i r C o n t r o l e r                                          *
 # *******************************************************************************
+class DrawLabelCommand(QUndoCommand):
+    def __init__(self, parent=None, *, sink, slicing, old_data, labels):
+        super().__init__(parent)
+        self.__old_data = old_data
+        self.__labels = labels
+        self.__slicing = slicing
+        self.__sink = sink
+
+    def redo(self):
+        redo_data = numpy.where(self.__labels != 0, self.__labels, self.__old_data)
+        redo_data = redo_data.astype(self.__labels.dtype)
+        self.__sink.put(self.__slicing, redo_data)
+
+    def undo(self):
+        undo_data = self.__old_data
+
+        if self.__sink.eraser_value is not None:
+            erase = numpy.where(self.__labels != 0, self.__sink.eraser_value, 0)  # What to do to erase new label fully
+            undo_data = numpy.where(self.__old_data, self.__old_data, erase)
+
+        undo_data = undo_data.astype(self.__labels.dtype)
+        self.__sink.put(self.__slicing, undo_data)
 
 
 class CrosshairController(QObject):
@@ -267,9 +290,10 @@ class BrushingInterpreter(QObject, InterpreterABC):
 class BrushingController(QObject):
     wroteToSink = pyqtSignal()
 
-    def __init__(self, brushingModel, positionModel, dataSink):
+    def __init__(self, brushingModel, positionModel, dataSink, *, undoStack):
         QObject.__init__(self, parent=None)
         self._dataSink = dataSink
+        self._undoStack = undoStack
 
         self._brushingModel = brushingModel
         self._brushingModel.brushStrokeAvailable.connect(self._writeIntoSink)
@@ -312,5 +336,11 @@ class BrushingController(QObject):
 
         # newlabels = numpy.zeros
         if self._dataSink != None:
-            self._dataSink.put(slicing, labels.reshape(tuple(newshape)))
+            new_labels = labels.reshape(tuple(newshape))
+            # Assuming ownership of the data, in case of array sink will be overwritten
+            old_data = self._dataSink.request(slicing).wait().copy()
+
+            cmd = DrawLabelCommand(sink=self._dataSink, slicing=slicing, old_data=old_data, labels=new_labels)
+
+            self._undoStack.push(cmd)
             self.wroteToSink.emit()

--- a/volumina/brushingcontroller.py
+++ b/volumina/brushingcontroller.py
@@ -37,6 +37,7 @@ class DrawLabelCommand(QUndoCommand):
     def __init__(self, parent=None, *, sink, slicing, old_data, labels):
         super().__init__(parent)
         self.__old_data = old_data
+        # 0 value is special in labels array. It means there is no data
         self.__labels = labels
         self.__slicing = slicing
         self.__sink = sink

--- a/volumina/pixelpipeline/datasources/arraysource.py
+++ b/volumina/pixelpipeline/datasources/arraysource.py
@@ -86,7 +86,7 @@ class ArraySinkSource(ArraySource):
 
 class RelabelingArraySource(ArraySource):
     """Applies a relabeling to each request before passing it on
-       Currently, it casts everything to uint8, so be careful."""
+    Currently, it casts everything to uint8, so be careful."""
 
     isDirty = pyqtSignal(object)
 
@@ -97,7 +97,7 @@ class RelabelingArraySource(ArraySource):
 
     def setRelabeling(self, relabeling):
         """Sets new relabeling vector. It should have a len(relabling) == max(your data)+1
-           and give, for each possible data value x, the relabling as relabeling[x]."""
+        and give, for each possible data value x, the relabling as relabeling[x]."""
         assert relabeling.dtype == self._array.dtype, "relabeling.dtype=%r != self._array.dtype=%r" % (
             relabeling.dtype,
             self._array.dtype,
@@ -111,10 +111,10 @@ class RelabelingArraySource(ArraySource):
 
     def setRelabelingEntry(self, index, value, setDirty=True):
         """Sets the entry for data value index to value, such that afterwards
-           relabeling[index] =  value.
+        relabeling[index] =  value.
 
-           If setDirty is true, the source will signal dirtyness. If you plan to issue many calls to this function
-           in a loop, setDirty to true only on the last call."""
+        If setDirty is true, the source will signal dirtyness. If you plan to issue many calls to this function
+        in a loop, setDirty to true only on the last call."""
         self._relabeling[index] = value
         if setDirty:
             self.setDirty(5 * (slice(None),))

--- a/volumina/pixelpipeline/datasources/arraysource.py
+++ b/volumina/pixelpipeline/datasources/arraysource.py
@@ -67,7 +67,9 @@ class ArraySource(QObject, DataSourceABC):
 
 
 class ArraySinkSource(ArraySource):
-    def put(self, slicing, subarray, neutral=0):
+    eraser_value = None
+
+    def put(self, slicing, subarray):
         """Make an update of the wrapped arrays content.
 
         Elements with neutral value in the subarray are not written into the
@@ -77,7 +79,7 @@ class ArraySinkSource(ArraySource):
         assert len(slicing) == len(
             self._array.shape
         ), "slicing into an array of shape=%r requested, but the slicing object is %r" % (slicing, self._array.shape)
-        self._array[slicing] = np.where(subarray != neutral, subarray, self._array[slicing])
+        self._array[slicing] = subarray
         pure = index2slice(slicing)
         self.setDirty(pure)
 

--- a/volumina/pixelpipeline/datasources/lazyflowsource.py
+++ b/volumina/pixelpipeline/datasources/lazyflowsource.py
@@ -179,14 +179,18 @@ class LazyflowSource(QObject, DataSourceABC):
 
 
 class LazyflowSinkSource(LazyflowSource):
-    def __init__(self, outslot, inslot, priority=0):
+    def __init__(self, outslot, inslot, priority=0, *, eraser_value=100):
         self._inputSlot = inslot
         self._priority = priority
-        LazyflowSource.__init__(self, outslot)
+        self._eraser_value = eraser_value
+        super().__init__(outslot)
+
+    @property
+    def eraser_value(self):
+        return self._eraser_value
 
     def put(self, slicing, array):
         assert _has_vigra, "Lazyflow SinkSource requires lazyflow and vigra."
-
         taggedArray = array.view(vigra.VigraArray)
         taggedArray.axistags = vigra.defaultAxistags("txyzc")
 
@@ -198,6 +202,7 @@ class LazyflowSinkSource(LazyflowSource):
         for k in inputKeys:
             if k in "txyzc":
                 transposedSlicing += (taggedSlicing[k],)
+
         self._inputSlot[transposedSlicing] = transposedArray.view(np.ndarray)
 
     def __eq__(self, other):

--- a/volumina/pixelpipeline/datasources/lazyflowsource.py
+++ b/volumina/pixelpipeline/datasources/lazyflowsource.py
@@ -67,9 +67,13 @@ class LazyflowRequest(RequestABC):
     def wait(self):
         a = self._req.wait()
         assert isinstance(a, np.ndarray)
-        assert a.shape == self._shape, (
-            "LazyflowRequest.wait() [name=%s]: we requested shape %s (slicing: %s), but lazyflow delivered shape %s"
-            % (self._objectName, self._shape, self._slicing, a.shape)
+        assert (
+            a.shape == self._shape
+        ), "LazyflowRequest.wait() [name=%s]: we requested shape %s (slicing: %s), but lazyflow delivered shape %s" % (
+            self._objectName,
+            self._shape,
+            self._slicing,
+            a.shape,
         )
         return a
 

--- a/volumina/volumeEditor.py
+++ b/volumina/volumeEditor.py
@@ -285,8 +285,8 @@ class VolumeEditor(QObject):
             idx = self._undoStack.index()
             self._undoStack.setIndex(min(cap, idx + 1))
 
-        mgr.register("Ctrl+Z", ActionInfo("Actions", "Undo", "Undo last action", _undo, self.parent, None))
-        mgr.register("Ctrl+Y", ActionInfo("Actions", "Redo", "Redo last action", _redo, self.parent, None))
+        mgr.register("Ctrl+Z", ActionInfo("Labeling", "Undo", "Undo last action", _undo, self.parent, None))
+        mgr.register("Ctrl+Y", ActionInfo("Labeling", "Redo", "Redo last action", _redo, self.parent, None))
 
     def _initImagePumps(self):
         alongTXC = SliceProjection(abscissa=2, ordinate=3, along=[0, 1, 4])

--- a/volumina/volumeEditor.py
+++ b/volumina/volumeEditor.py
@@ -30,7 +30,7 @@ import numpy
 
 # PyQt
 from PyQt5.QtCore import pyqtSignal, QObject
-from PyQt5.QtWidgets import QApplication, QWidget
+from PyQt5.QtWidgets import QApplication, QWidget, QUndoStack
 
 # volumina
 import volumina.pixelpipeline.imagepump
@@ -44,6 +44,7 @@ from .brushingcontroller import BrushingInterpreter, BrushingController, Crossha
 from .thresholdingcontroller import ThresholdingInterpreter
 from .brushingmodel import BrushingModel
 from .slicingtools import SliceProjection
+from .utility import ShortcutManager
 
 import logging
 
@@ -161,6 +162,7 @@ class VolumeEditor(QObject):
         ##
         ## base components
         ##
+        self._undoStack = QUndoStack()
         self.layerStack = layerStackModel
         self.posModel = PositionModel(self)
         self.brushingModel = BrushingModel()
@@ -206,7 +208,9 @@ class VolumeEditor(QObject):
         # brushing control
         if crosshair:
             self.crosshairController = CrosshairController(self.brushingModel, self.imageViews)
-        self.brushingController = BrushingController(self.brushingModel, self.posModel, labelsink)
+        self.brushingController = BrushingController(
+            self.brushingModel, self.posModel, labelsink, undoStack=self._undoStack
+        )
         self.brushingInterpreter = BrushingInterpreter(self.navCtrl, self.brushingController)
 
         for v in self.imageViews:
@@ -229,6 +233,7 @@ class VolumeEditor(QObject):
 
         self.layerStack.layerAdded.connect(self._onLayerAdded)
         self.parent = parent
+        self._setUpShortcuts()
 
     def _reset(self):
         for s in self.imageScenes:
@@ -267,6 +272,22 @@ class VolumeEditor(QObject):
     ##
     ## private
     ##
+    def _setUpShortcuts(self):
+        mgr = ShortcutManager()
+        ActionInfo = ShortcutManager.ActionInfo
+
+        def _undo():
+            idx = self._undoStack.index()
+            self._undoStack.setIndex(idx - 1)
+
+        def _redo():
+            cap = self._undoStack.count()
+            idx = self._undoStack.index()
+            self._undoStack.setIndex(min(cap, idx + 1))
+
+        mgr.register("Ctrl+Z", ActionInfo("Actions", "Undo", "Undo last action", _undo, self.parent, None))
+        mgr.register("Ctrl+Y", ActionInfo("Actions", "Redo", "Redo last action", _redo, self.parent, None))
+
     def _initImagePumps(self):
         alongTXC = SliceProjection(abscissa=2, ordinate=3, along=[0, 1, 4])
         alongTYC = SliceProjection(abscissa=1, ordinate=3, along=[0, 2, 4])


### PR DESCRIPTION
Demo with hotkeys Ctrl+Z for undo and Ctrl+Y for redo.
Example script for labeling in `examples/labeling.py`
![undo-redo](https://user-images.githubusercontent.com/5163640/93672146-e1533d80-faa8-11ea-99ab-66b1891e1e12.gif)
Doesn't work for lazyflow slots.
Why do LF sinks have separate input and output?