### PR TITLE
temporary fix: fail a little more gracefully on pref import fail

### DIFF
--- a/tests/test_utility/test_preferences.py
+++ b/tests/test_utility/test_preferences.py
@@ -57,3 +57,19 @@ def test_migrate_noop(tmp_path, preferences):
 
     assert old_path.exists()
     assert not preferences.read()
+
+
+def test_migrate_failure(tmp_path, preferences):
+    # TODO: these shortcuts should actually be imported!
+    # see https://github.com/ilastik/ilastik/issues/2323
+    # see https://github.com/ilastik/ilastik/issues/2322
+    data = {"Shortcut Preferences v2": {"all_shortcuts": {("Ilastik Shell", "shell next image"): "PgDown"}}}
+
+    old_path = tmp_path / "old_preferences.pickle"
+    with open(old_path, "wb") as f:
+        pickle.dump(data, f)
+
+    preferences.migrate(old_path)
+
+    key = ("Shortcut Preferences v2", "all_shortcuts")
+    assert preferences.get(*key) is None

--- a/volumina/utility/preferences.py
+++ b/volumina/utility/preferences.py
@@ -100,6 +100,12 @@ class Preferences:
         except Exception:
             return
 
+        try:
+            _ = json.dumps(old_preferences)
+        except Exception:
+            logger.warning("Encountered an exception on preferences import - skipping import.")
+            return
+
         self.write(old_preferences)
         old_path.unlink()
 


### PR DESCRIPTION
this is _not_ the proper way to do it, we should still import all
preference properly (key bindings) https://github.com/ilastik/ilastik/issues/2323, and ignore deprecated ones https://github.com/ilastik/ilastik/issues/2322 that
also result in failures.

We need to fix this quickly for the release
This should of course be followed up properly.

This PR preserves the old file if import failed with the hope we'll properly fix it at some point.