### PR TITLE
Save shortcuts as list of dicts

### DIFF
--- a/tests/test_utility/test_preferences.py
+++ b/tests/test_utility/test_preferences.py
@@ -35,23 +35,21 @@ def test_set_path(tmp_path, preferences):
 
 def test_migrate(tmp_path, preferences):
     data = {"s1": {"k1": "spam"}, "s2": {"k2": 42, "k3": True, "k4": 0.42, "k5": None}}
-
     old_path = tmp_path / "old_preferences.pickle"
-    with open(old_path, "wb") as f:
-        pickle.dump(data, f)
+    old_path.write_bytes(pickle.dumps(data))
 
     preferences.migrate(old_path)
 
-    assert not old_path.exists()
+    assert old_path.exists()
 
     m = type("Missing", (), {"__repr__": lambda _self: "<missing>"})()
     keys = ("s1", "k1", m), ("s2", "k2", m), ("s2", "k3", m), ("s2", "k4", m), ("s2", "k5", m)
     assert preferences.getmany(*keys) == ("spam", 42, True, 0.42, None)
 
 
-def test_migrate_noop(tmp_path, preferences):
+def test_migrate_invalid_data(tmp_path, preferences):
     old_path = tmp_path / "old_preferences.pickle"
-    old_path.touch()
+    old_path.write_bytes(pickle.dumps(object()))
 
     preferences.migrate(old_path)
 

--- a/tests/test_utility/test_preferences.py
+++ b/tests/test_utility/test_preferences.py
@@ -59,10 +59,7 @@ def test_migrate_noop(tmp_path, preferences):
     assert not preferences.read()
 
 
-def test_migrate_failure(tmp_path, preferences):
-    # TODO: these shortcuts should actually be imported!
-    # see https://github.com/ilastik/ilastik/issues/2323
-    # see https://github.com/ilastik/ilastik/issues/2322
+def test_migrate_shortcuts(tmp_path, preferences):
     data = {"Shortcut Preferences v2": {"all_shortcuts": {("Ilastik Shell", "shell next image"): "PgDown"}}}
 
     old_path = tmp_path / "old_preferences.pickle"
@@ -71,5 +68,5 @@ def test_migrate_failure(tmp_path, preferences):
 
     preferences.migrate(old_path)
 
-    key = ("Shortcut Preferences v2", "all_shortcuts")
-    assert preferences.get(*key) is None
+    shortcuts = [{"group": "Ilastik Shell", "name": "shell next image", "keyseq": "PgDown"}]
+    assert preferences.get("Shortcut Preferences v2", "all_shortcuts") == shortcuts

--- a/volumina/utility/preferences.py
+++ b/volumina/utility/preferences.py
@@ -106,16 +106,15 @@ class Preferences:
         from volumina.utility import ShortcutManager as SM
 
         try:
-            with open(old_path, "rb") as f:
-                old_preferences = pickle.load(f)
-                # Old pickled preferences saved shortcuts as a dict
-                # with tuple keys, but JSON can only have string keys,
-                # so transform the old dict into the new format.
-                reversemap = old_preferences.get(SM.PreferencesGroup, {}).get(SM.PreferencesSetting, {})
-                if reversemap:
-                    old_preferences.setdefault(SM.PreferencesGroup, {})[SM.PreferencesSetting] = [
-                        {"group": group, "name": name, "keyseq": keyseq} for (group, name), keyseq in reversemap.items()
-                    ]
+            old_preferences = pickle.loads(old_path.read_bytes())
+            # Old pickled preferences saved shortcuts as a dict
+            # with tuple keys, but JSON can only have string keys,
+            # so transform the old dict into the new format.
+            reversemap = old_preferences.get(SM.PreferencesGroup, {}).get(SM.PreferencesSetting, {})
+            if reversemap:
+                old_preferences.setdefault(SM.PreferencesGroup, {})[SM.PreferencesSetting] = [
+                    {"group": group, "name": name, "keyseq": keyseq} for (group, name), keyseq in reversemap.items()
+                ]
         except Exception:
             logger.exception("Failed to read old preferences")
             return

--- a/volumina/utility/preferences.py
+++ b/volumina/utility/preferences.py
@@ -113,7 +113,7 @@ class Preferences:
                 # so transform the old dict into the new format.
                 reversemap = old_preferences.get(SM.PreferencesGroup, {}).get(SM.PreferencesSetting, {})
                 if reversemap:
-                    old_preferences[SM.PreferencesGroup][SM.PreferencesSetting] = [
+                    old_preferences.setdefault(SM.PreferencesGroup, {})[SM.PreferencesSetting] = [
                         {"group": group, "name": name, "keyseq": keyseq} for (group, name), keyseq in reversemap.items()
                     ]
         except Exception:


### PR DESCRIPTION
Old pickled preferences saved shortcuts as a dict with tuple keys, but
JSON can only have string keys, so transform the old dict into the new
format.

Closes https://github.com/ilastik/ilastik/issues/2323