### PR TITLE
Set tilewidth automatically for 2D and 3D data

### DIFF
--- a/volumina/imageScene2D.py
+++ b/volumina/imageScene2D.py
@@ -40,7 +40,6 @@ from PyQt5.QtGui import QTransform, QPen, QColor, QBrush, QPolygonF, QPainter, Q
 from volumina.tiling import Tiling, TileProvider
 from volumina.layerstack import LayerStackModel
 from volumina.pixelpipeline.imagepump import StackedImageSources
-from volumina.utility import preferences
 
 import datetime
 import threading
@@ -296,7 +295,7 @@ class ImageScene2D(QGraphicsScene):
 
     def setTileWidth(self, tileWidth):
         self._tileWidth = tileWidth
-        preferences.set("ImageScene2D", "tileWidth", tileWidth)
+        self.reset()
 
     def tileWidth(self):
         return self._tileWidth
@@ -400,7 +399,7 @@ class ImageScene2D(QGraphicsScene):
         self._offsetX = 0
         self._offsetY = 0
         self.name = name
-        self._tileWidth = preferences.get("ImageScene2D", "tileWidth", default=512)
+        self._tileWidth = 256
 
         self._stackedImageSources = StackedImageSources(LayerStackModel())
         self._showTileOutlines = False

--- a/volumina/volumeEditor.py
+++ b/volumina/volumeEditor.py
@@ -255,6 +255,10 @@ class VolumeEditor(QObject):
         for view in self.imageViews:
             view.showCropLines(visible)
 
+    def setTileWidth(self, tileWidth):
+        for i in self.imageScenes:
+            i.setTileWidth(tileWidth)
+
     def cleanUp(self):
         QApplication.processEvents()
         for scene in self._imageViews:

--- a/volumina/volumeEditorWidget.py
+++ b/volumina/volumeEditorWidget.py
@@ -59,6 +59,7 @@ from .sliceSelectorHud import ImageView2DHud, QuadStatusBar
 from .pixelpipeline.datasources import ArraySource
 from .volumeEditor import VolumeEditor
 from volumina.utility import ShortcutManager
+from volumina.utility import preferences
 
 
 class __TimerEventEater(QObject):
@@ -269,6 +270,8 @@ class VolumeEditorWidget(QWidget):
                     self.editor.imageViews[i].setHudVisible(self.hudsShown[i])
                 self.quadview.statusBar.crosshairsCheckbox.setChecked(False)
 
+            self._updateTileWidth()
+
             self.quadview.statusBar.crosshairsCheckbox.setVisible(True)
 
             if self.editor.cropModel.cropZero() or None in self.editor.cropModel.get_roi_3d()[0]:
@@ -323,6 +326,33 @@ class VolumeEditorWidget(QWidget):
                 self.editor.imageViews[self.editor._lastImageViewFocus].setCursor(
                     self.editor.imageViews[self.editor._lastImageViewFocus]._cursorBackup
                 )
+
+    def _updateTileWidth(self):
+        tile_width = self._getTileWidth()
+        self.editor.setTileWidth(tile_width)
+
+    def _getTileWidthConfigKeyDefault(self):
+        singletons_spacial = [True for dim in self.editor.posModel.shape if dim == 1]
+        assert len(singletons_spacial) in range(2)
+        if len(singletons_spacial) == 0:
+            # 3D data
+            key = "tileWidth3D"
+            default = 256
+        else:
+            # 2D data
+            key = "tileWidth"
+            default = 512
+        return key, default
+
+    def _getTileWidth(self):
+        key, default = self._getTileWidthConfigKeyDefault()
+        tile_width = preferences.get("ImageScene2D", key, default=default)
+        return tile_width
+
+    def _setTileWidth(self, value):
+        key, _ = self._getTileWidthConfigKeyDefault()
+        preferences.set("ImageScene2D", key, value)
+        self._updateTileWidth()
 
     def _toggleHUDs(self, checked):
         for v in self.editor.imageViews:
@@ -576,9 +606,10 @@ class VolumeEditorWidget(QWidget):
             dlg.setWindowTitle("Viewer Tile Width")
             dlg.setModal(True)
 
+            saved = self._getTileWidth()
             spinBox = QSpinBox(parent=dlg)
             spinBox.setRange(128, 10 * 1024)
-            spinBox.setValue(self.editor.imageScenes[0].tileWidth())
+            spinBox.setValue(saved)
 
             ctrl_layout = QHBoxLayout()
             ctrl_layout.addSpacerItem(QSpacerItem(10, 0, QSizePolicy.Expanding))
@@ -599,10 +630,8 @@ class VolumeEditorWidget(QWidget):
             dlg.setLayout(dlg_layout)
 
             if dlg.exec_() == QDialog.Accepted:
-                for s in self.editor.imageScenes:
-                    if s.tileWidth != spinBox.value():
-                        s.setTileWidth(spinBox.value())
-                        s.reset()
+                if spinBox.value() != saved:
+                    self._setTileWidth(spinBox.value())
 
         self._viewMenu.addAction("Set Tile Width...").triggered.connect(changeTileWidth)
 

--- a/volumina/volumeEditorWidget.py
+++ b/volumina/volumeEditorWidget.py
@@ -628,6 +628,7 @@ class VolumeEditorWidget(QWidget):
             dlg_layout.addWidget(button_box)
 
             dlg.setLayout(dlg_layout)
+            spinBox.setFocus()
 
             if dlg.exec_() == QDialog.Accepted:
                 if spinBox.value() != saved:

--- a/volumina/volumeEditorWidget.py
+++ b/volumina/volumeEditorWidget.py
@@ -332,9 +332,9 @@ class VolumeEditorWidget(QWidget):
         self.editor.setTileWidth(tile_width)
 
     def _getTileWidthConfigKeyDefault(self):
-        singletons_spacial = [True for dim in self.editor.posModel.shape if dim == 1]
-        assert len(singletons_spacial) in range(2)
-        if len(singletons_spacial) == 0:
+        singletons_spacial = sum(1 for dim in self.editor.posModel.shape if dim == 1)
+        assert singletons_spacial in range(2)
+        if singletons_spacial == 0:
             # 3D data
             key = "tileWidth3D"
             default = 256


### PR DESCRIPTION
I cannot believe that we did not have an issue about this open @akreshuk, but I couldn't find one.
With this PR we add a new preference key `"tileWidth3D"` which will be used to set tile width for 3D data. The preference key `"tileWidth"` remains and will be used for 2D data. Defaults are 256 for 3D, 512 for 2D.
I also moved responsibility for the preference handling from `ImageScene2D` to `VolumeEditorWidget`.

Added the setFocus so this PR actually closes an issue ;)
fixes ilastik/ilastik#2260