### PR TITLE
fix short cut action slice up

### DIFF
--- a/volumina/volumeEditorWidget.py
+++ b/volumina/volumeEditorWidget.py
@@ -451,8 +451,8 @@ class VolumeEditorWidget(QWidget):
                 "Ctrl+Down",
                 ActionInfo(
                     "Navigation",
-                    "Slice up",
-                    "Slice up",
+                    "Slice down",
+                    "Slice down",
                     partial(sliceDelta, i, -1),
                     v,
                     v.hud.buttons["slice"].downLabel,


### PR DESCRIPTION
fixes https://github.com/ilastik/ilastik/issues/2422

looks like there was some copy-paste issue

Maybe interesting to add, that having a second shortcut on the same action seems to silently disable the action - no errors whatsoever...