### PR TITLE
reflect default branch rename to main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   black:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test-w-ilastik-env:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,4 +3,4 @@
 # Code of Conduct
 
 Thank you for considering contributing to volumina, we really appreciate it.
-Please make sure to adhere to our [Code of Conduct](https://github.com/ilastik/ilastik/blob/master/CODE_OF_CONDUCT.md) in order to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation..
+Please make sure to adhere to our [Code of Conduct](https://github.com/ilastik/ilastik/blob/main/CODE_OF_CONDUCT.md) in order to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation..

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing
 
 Thank you for considering contributing to volumina, we really appreciate it.
-You can find detailed contributing information in our main repository [ilastik](https://github.com/ilastik/ilastik): [CONTRIBUTING](https://github.com/ilastik/ilastik/blob/master/CONTRIBUTING.md)
+You can find detailed contributing information in our main repository [ilastik](https://github.com/ilastik/ilastik): [CONTRIBUTING](https://github.com/ilastik/ilastik/blob/main/CONTRIBUTING.md)

--- a/Readme.md
+++ b/Readme.md
@@ -34,4 +34,4 @@ Volumina Development
 Create a development environment
 --------------------------------
 
-To set up a development environment, we currently recommend to follow Contributing Guidelines of our main repository [ilastik](https://github.com/ilastik/ilastik): [CONTRIBUTING](https://github.com/ilastik/ilastik/blob/master/CONTRIBUTING.md)
+To set up a development environment, we currently recommend to follow Contributing Guidelines of our main repository [ilastik](https://github.com/ilastik/ilastik): [CONTRIBUTING](https://github.com/ilastik/ilastik/blob/main/CONTRIBUTING.md)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - pyqtgraph
     - qimage2ndarray
     - typing_extensions
+    - lemon <=1.3.1=*_3
     - vigra
     - xarray
 


### PR DESCRIPTION
Unrelated:

* Pinned lemon such that it is for sure a shared lib version. For some reason the solver might pick one of the old builds. Pinning it will not cause any problems - lemon doesn't really have upstream deps.