### PR TITLE
Allow build/run with Pyhton 3.9

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,12 +9,12 @@ source:
 
 requirements:
   host:
-    - python >=3.7,<3.9
+    - python >=3.7,<3.10
     - pip
     - setuptools >=40.0
     - setuptools_scm
   run:
-    - python >=3.7,<3.9
+    - python >=3.7,<3.10
     - appdirs
     - cachetools
     - future
@@ -24,7 +24,6 @@ requirements:
     - pyqtgraph
     - qimage2ndarray
     - typing_extensions
-    - lemon <=1.3.1=*_3
     - vigra
     - xarray
 

--- a/tests/imagesources_test.py
+++ b/tests/imagesources_test.py
@@ -104,12 +104,6 @@ class ImageSourcesTestBase(ut.TestCase):
         self._my_thread = threading.current_thread()
 
     def tearDown(self):
-        # Block for all other (non-daemon) threads to complete so we
-        #  catch any exceptions they caught before we exit.
-        for thread in threading.enumerate():
-            if thread != threading.current_thread() and not thread.daemon:
-                thread.join()
-
         # Check to see if this test caused any exceptions in other threads.
         global imagesources_thread_failures
         if imagesources_thread_failures != 0:


### PR DESCRIPTION
Tests were hanging in Python 3.9 because `ThreadpoolExecutor` doesn't start threads as daemon threads anymore...