### PR TITLE
fix valuerange widget for floats

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -57,6 +57,7 @@ test:
 
   requires:
     - pytest
+    - pytest-qt
   commands:
     - pytest .
     - volumina --help

--- a/tests/valueRangeWidget_test.py
+++ b/tests/valueRangeWidget_test.py
@@ -1,0 +1,28 @@
+import numpy
+import pytest
+from volumina.widgets.valueRangeWidget import ValueRangeWidget
+
+
+@pytest.mark.parametrize("dtype", [numpy.float32, numpy.float64, float])
+def test_floating_range(qtbot, dtype):
+    """repro of https://github.com/ilastik/ilastik/issues/2542"""
+    vrwidget = ValueRangeWidget()
+    qtbot.addWidget(vrwidget)
+    vrwidget.show()
+    qtbot.waitForWindowShown(vrwidget)
+    vrwidget.setDType(dtype)
+    minmax = vrwidget.getValues()
+    minmax_expected = numpy.finfo(dtype).min, numpy.finfo(dtype).max
+    numpy.testing.assert_array_almost_equal(minmax, minmax_expected)
+
+
+@pytest.mark.parametrize("dtype", [numpy.int8, numpy.uint8, numpy.int16, numpy.uint16, numpy.int32, numpy.uint32, int])
+def test_integer_range(qtbot, dtype):
+    vrwidget = ValueRangeWidget()
+    qtbot.addWidget(vrwidget)
+    vrwidget.show()
+    qtbot.waitForWindowShown(vrwidget)
+    vrwidget.setDType(dtype)
+    minmax = vrwidget.getValues()
+    minmax_expected = numpy.iinfo(dtype).min, numpy.iinfo(dtype).max
+    numpy.testing.assert_array_equal(minmax, minmax_expected)

--- a/volumina/widgets/valueRangeWidget.py
+++ b/volumina/widgets/valueRangeWidget.py
@@ -63,7 +63,7 @@ class ValueRangeWidget(QWidget):
 
     def setDType(self, dtype):
         self.dtype = dtype
-        if numpy.issubdtype(dtype, numpy.float):
+        if numpy.issubdtype(dtype, numpy.floating):
             dtypeInfo = numpy.finfo(dtype)
             for box in self.boxes:
                 box.setDecimals(2)


### PR DESCRIPTION
this is related to numpy upgrade >=1.19:
https://numpy.org/doc/stable/release/1.19.0-notes.html#issubdtype-no-longer-interprets-float-as-np-floating

fixes https://github.com/ilastik/ilastik/issues/2542