### PR TITLE
Fix Scrolling: Alt + mouse wheel

### DIFF
--- a/volumina/navigationController.py
+++ b/volumina/navigationController.py
@@ -21,6 +21,7 @@
 ###############################################################################
 
 import copy
+import sys
 from functools import partial
 
 import volumina
@@ -33,7 +34,7 @@ from volumina.sliceIntersectionMarker import SliceIntersectionMarker
 
 def posView2D(pos3d, axis):
     """convert from a 3D position to a 2D position on the slicing plane
-       perpendicular to axis"""
+    perpendicular to axis"""
     pos2d = list(copy.deepcopy(pos3d))
     del pos2d[axis]
     return pos2d
@@ -148,7 +149,10 @@ class NavigationInterpreter(QObject, InterpreterABC):
         grviewCenter = imageview.mapToScene(imageview.viewport().rect().center())
 
         sign = 1
-        if event.angleDelta().y() < 0:
+        # Qt.AltModifier maps vertical (y) to horizontal (x) scrolling direction
+        if sys.platform != "darwin" and (k_alt or k_shift_alt) and event.angleDelta().x() < 0:
+            sign = -1
+        elif event.angleDelta().y() < 0:
             sign = -1
 
         if k_shift_alt:


### PR DESCRIPTION
Fix issue ilastik/ilastik#2009

Qt.AltModifier inverts vertical and horizontal scrolling directions as an [intended behaviour](https://bugreports.qt.io/browse/QTBUG-30948?focusedCommentId=202503&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-202503)

The change in indentation in line 36 was caused by `hook id: black` while committing.
Thus, I refrained from reverting it this time, but appreciate tips how to avoid such changes in the first place in the future.


## Checklist

<!-- Checking off an item means that an action has been successfully completed.
     Some items might not be applicable - you can remove those if you decide
     that this is the case.
-->

- [x] Format code and imports.
- [x] Add comment.

