### PR TITLE
Pin black version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.kate-swp
 .ropeproject
 *.DS_Store
+*.egg-info/
 
 # pycharm project settings
 .idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-- repo: https://github.com/ambv/black
-  rev: 22.12.0
+- repo: https://github.com/psf/black
+  rev: 21.7b0
   hooks:
   - id: black
     language_version: python3.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: stable
+  rev: 22.12.0
   hooks:
   - id: black
     language_version: python3.7


### PR DESCRIPTION
`pre-commit` complains when using a repo with branch name as a ref.

Also, add `*.egg-info` directory from `pip install -e` to `.gitignore`.