### PR TITLE
Disallow bad pyqt5-sip versions

### DIFF
--- a/.github/workflows/etc/ilastik-env.yaml
+++ b/.github/workflows/etc/ilastik-env.yaml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python 3.9.*
   - ilastik-core
+  - pyqt5-sip !=12.9.0,!=12.13.0
   - qimage2ndarray
   - pyqtgraph
   - conda-build


### PR DESCRIPTION
This changes nothing that could make the pipeline fail.