### PR TITLE
Silence tilescache warning

### DIFF
--- a/volumina/tiling/cache.py
+++ b/volumina/tiling/cache.py
@@ -219,10 +219,8 @@ class TilesCache:
         """
         assert self._lock.locked(), "You must claim the _TileCache via a context manager before calling this function."
 
-        warnings.warn(
-            "FIXME: This is a slow way to look for the items we want.\n"
-            "TilesCache._layerCache should be a dict-of-dict-of-dict for faster lookup!"
-        )
+        # FIXME: This is a slow way to look for the items we want.
+        # TilesCache._layerCache should be a dict-of-dict-of-dict for faster lookup!
         qgraphicsitems = []
         for (layer_id, t_id), img in self._layerCache[stack_id].items():
             if t_id == tile_id and isinstance(img, QGraphicsItem):


### PR DESCRIPTION
fixmes are not user warnings. This message appears for every user on win and linux (not to mention our test logs), and it's pointless for them.