### PR TITLE
Consistently paint loading tiles white

### DIFF
--- a/volumina/tiling/tileprovider.py
+++ b/volumina/tiling/tileprovider.py
@@ -322,7 +322,7 @@ class TileProvider(QObject):
             # Don't create white "loading" tiles if there is nothing at all to display
             return None
         qimg = QImage(self.tiling.imageRects[tile_nr].size(), QImage.Format_ARGB32_Premultiplied)
-        qimg.fill(0xFFFFFFFF)
+        qimg.fill(0x00FFFFFF)
         p = QPainter(qimg)
         for i, (visible, layerOpacity, layerImageSource) in enumerate(reversed(self._sims)):
             image_type = layerImageSource.image_type()


### PR DESCRIPTION
This unifies loading behaviour across applets in ilastik. Previously, applets that only display raw data would leave unloaded tiles invisible, while applets with sparse layers (e.g. user labels) would paint tiles white until data is loaded.

The below example shows the viewer in the data selection applet, where the behaviour now changes. In other applets, e.g. pixel classification Training, the viewer already behaves like in the "After" screenshot.

Unifying the behaviour in the opposite direction (making the "Before" the default everywhere) would be harder, because then volumina would have to inspect layer-tile contents after loading them to determine whether they are empty (and hence whether to paint them). Probably wouldn't be too nasty in terms of performance, but I think the white loading tile is better anyway?

Before:
![image](https://github.com/user-attachments/assets/9fd319de-3df3-40f3-b103-321eb664c8b5)

After:
![image](https://github.com/user-attachments/assets/c31b6343-4117-4d42-89da-47664aa11eec)
