### PR TITLE
Stop caching failed requests

### DIFF
--- a/tests/test_pixelpipeline/test_datasources/test_cachesource.py
+++ b/tests/test_pixelpipeline/test_datasources/test_cachesource.py
@@ -33,54 +33,58 @@ class DummySource(QObject):
         return self._Req(self._data[slicing])
 
 
-class TestCacheSource:
-    @pytest.fixture
-    def orig_source(self):
-        arr = np.arange(60).reshape(3, 4, 5)
-        source = DummySource(arr)
-        return mock.Mock(wraps=source)
+@pytest.fixture
+def raw_source():
+    arr = np.arange(60).reshape(3, 4, 5)
+    source = DummySource(arr)
+    return mock.Mock(wraps=source)
 
-    @pytest.fixture
-    def cached_source(self, orig_source):
-        return CacheSource(orig_source)
 
-    def test_consecutive_requests_are_cached(self, cached_source, orig_source):
-        slicing = np.s_[1:2, 2:3, 3:4]
-        res0 = cached_source.request(slicing).wait()
-        res1 = cached_source.request(slicing).wait()
+@pytest.fixture
+def cached_source(raw_source):
+    return CacheSource(raw_source)
 
-        assert_array_equal(np.array([[[33]]]), res0)
-        assert_array_equal(np.array([[[33]]]), res1)
 
-        orig_source.request.assert_called_once_with(slicing)
+def test_consecutive_requests_are_cached(cached_source, raw_source):
+    slicing = np.s_[1:2, 2:3, 3:4]
+    res0 = cached_source.request(slicing).wait()
+    res1 = cached_source.request(slicing).wait()
 
-    def test_cache_invalidation(self, cached_source, orig_source):
-        slicing = np.s_[2:3, 0:1, 2:3]
-        res0 = cached_source.request(slicing).wait()
-        res1 = cached_source.request(slicing).wait()
+    assert_array_equal(np.array([[[33]]]), res0)
+    assert_array_equal(np.array([[[33]]]), res1)
 
-        assert_array_equal(np.array([[[42]]]), res0)
-        assert_array_equal(np.array([[[42]]]), res1)
+    raw_source.request.assert_called_once_with(slicing)
 
-        orig_source.set_data(np.arange(27, 87).reshape(3, 4, 5))
-        res2 = cached_source.request(slicing).wait()
-        assert_array_equal(np.array([[[69]]]), res2)
-        assert orig_source.request.call_count == 2
 
-    def test_cache_results_are_readonly(self, cached_source, orig_source):
-        slicing = np.s_[2:3, 0:1, 2:3]
-        res = cached_source.request(slicing).wait()
+def test_cache_invalidation(cached_source, raw_source):
+    slicing = np.s_[2:3, 0:1, 2:3]
+    res0 = cached_source.request(slicing).wait()
+    res1 = cached_source.request(slicing).wait()
 
-        with pytest.raises(ValueError):
-            res[0] = 100
+    assert_array_equal(np.array([[[42]]]), res0)
+    assert_array_equal(np.array([[[42]]]), res1)
 
-    def test_cache_if_value_is_too_large(self, orig_source):
-        cached_source = CacheSource(orig_source, cache=KVCache(1, getsizeof=sys.getsizeof))
-        slicing = np.s_[2:3, 0:1, 2:3]
-        res0 = cached_source.request(slicing).wait()
-        res1 = cached_source.request(slicing).wait()
+    raw_source.set_data(np.arange(27, 87).reshape(3, 4, 5))
+    res2 = cached_source.request(slicing).wait()
+    assert_array_equal(np.array([[[69]]]), res2)
+    assert raw_source.request.call_count == 2
 
-        assert_array_equal(np.array([[[42]]]), res0)
-        assert_array_equal(np.array([[[42]]]), res1)
 
-        assert orig_source.request.call_count == 2
+def test_cache_results_are_readonly(cached_source):
+    slicing = np.s_[2:3, 0:1, 2:3]
+    res = cached_source.request(slicing).wait()
+
+    with pytest.raises(ValueError):
+        res[0] = 100
+
+
+def test_cache_if_value_is_too_large(raw_source):
+    cached_source = CacheSource(raw_source, cache=KVCache(1, getsizeof=sys.getsizeof))
+    slicing = np.s_[2:3, 0:1, 2:3]
+    res0 = cached_source.request(slicing).wait()
+    res1 = cached_source.request(slicing).wait()
+
+    assert_array_equal(np.array([[[42]]]), res0)
+    assert_array_equal(np.array([[[42]]]), res1)
+
+    assert raw_source.request.call_count == 2

--- a/tests/test_pixelpipeline/test_datasources/test_cachesource.py
+++ b/tests/test_pixelpipeline/test_datasources/test_cachesource.py
@@ -33,6 +33,26 @@ class DummySource(QObject):
         return self._Req(self._data[slicing])
 
 
+class ErrorSource(DummySource):
+    class ErrorReq:
+        def wait(self):
+            # Lazyflow requests are single-use. If they fail first try, they are permanently failed.
+            # Lazyflow persists this state in Request.exception and Request.finished,
+            # but in this test it's enough to just have a request that always fails.
+            raise Exception("shouldn't retry a failed request")
+
+    def __init__(self, data):
+        self.n_requests = 0
+        super().__init__(data)
+
+    def request(self, slicing):
+        # Return a functioning request only on second attempt.
+        self.n_requests += 1
+        if self.n_requests == 1:
+            return self.ErrorReq()
+        return super().request(slicing)
+
+
 @pytest.fixture
 def raw_source():
     arr = np.arange(60).reshape(3, 4, 5)
@@ -43,6 +63,18 @@ def raw_source():
 @pytest.fixture
 def cached_source(raw_source):
     return CacheSource(raw_source)
+
+
+@pytest.fixture
+def raw_error_source():
+    arr = np.arange(60).reshape(3, 4, 5)
+    source = ErrorSource(arr)
+    return mock.Mock(wraps=source)
+
+
+@pytest.fixture
+def cached_error_source(raw_error_source):
+    return CacheSource(raw_error_source)
 
 
 def test_consecutive_requests_are_cached(cached_source, raw_source):
@@ -88,3 +120,16 @@ def test_cache_if_value_is_too_large(raw_source):
     assert_array_equal(np.array([[[42]]]), res1)
 
     assert raw_source.request.call_count == 2
+
+
+def test_cache_drops_errored_request(cached_error_source):
+    slicing = np.s_[2:3, 0:1, 2:3]
+
+    # First try errors
+    with pytest.raises(Exception):
+        cached_error_source.request(slicing).wait()
+
+    # Second try should work
+    res = cached_error_source.request(slicing).wait()
+
+    assert_array_equal(np.array([[[42]]]), res)

--- a/tests/test_pixelpipeline/test_datasources/test_factories.py
+++ b/tests/test_pixelpipeline/test_datasources/test_factories.py
@@ -62,7 +62,7 @@ DIMS = SimpleNamespace(t=2, c=3, z=10, x=32, y=64)
 )
 def test_lazyflow_tagged_shape_embedding(lazyflow_op, vigra, dims, expected_shape, transpose):
     shape = select(DIMS, dims)
-    len_ = np.product(shape)
+    len_ = np.prod(shape)
 
     array = np.array(range(len_)).reshape(shape).view(vigra.VigraArray)
     array.axistags = vigra.defaultAxistags(dims)

--- a/volumina/pixelpipeline/datasources/cachesource.py
+++ b/volumina/pixelpipeline/datasources/cachesource.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 import sys
+import uuid
 from typing import Union
 
 from PyQt5.QtCore import QObject, pyqtSignal
@@ -71,6 +72,7 @@ class CacheSource(QObject, DataSourceABC):
         super().__init__()
         self._lock = threading.Lock()
 
+        self._uniqueid = uuid.uuid4()  # id(self) wasn't unique enough
         self._source = source
         self._cache = cache
         self._req = {}
@@ -84,7 +86,7 @@ class CacheSource(QObject, DataSourceABC):
         self._req.clear()
 
     def __cache_key(self, slicing):
-        parts = [id(self)]
+        parts = [self._uniqueid]
 
         for el in slicing:
             _, key_part = el.__reduce__()

--- a/volumina/pixelpipeline/datasources/cachesource.py
+++ b/volumina/pixelpipeline/datasources/cachesource.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 import sys
+from typing import Union
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -16,7 +17,7 @@ ARRAY_CACHE = KVCache(CONFIG.cache_size, getsizeof=sys.getsizeof)
 
 
 class _Request:
-    def __init__(self, cached_source, slicing, key):
+    def __init__(self, cached_source: "CacheSource", slicing, key):
         self._cached_source = cached_source
         self._slicing = slicing
         self._key = key
@@ -69,7 +70,7 @@ class CacheSource(QObject, DataSourceABC):
     isDirty = pyqtSignal(object)
     numberOfChannelsChanged = pyqtSignal(int)
 
-    def __init__(self, source, cache=ARRAY_CACHE):
+    def __init__(self, source: "LazyflowSource", cache=ARRAY_CACHE):
         super().__init__()
         self._lock = threading.Lock()
 
@@ -94,7 +95,7 @@ class CacheSource(QObject, DataSourceABC):
 
         return "::".join(str(p) for p in parts)
 
-    def request(self, slicing):
+    def request(self, slicing) -> Union[_CachedRequest, _Request]:
         key = self.__cache_key(slicing)
 
         with self._lock:

--- a/volumina/pixelpipeline/datasources/cachesource.py
+++ b/volumina/pixelpipeline/datasources/cachesource.py
@@ -44,10 +44,7 @@ class _Request:
                         self._cached_source._cache.getsizeof(cached_copy),
                     )
         finally:
-            try:
-                self._cached_source._req.pop(self._key, None)
-            except KeyError:
-                pass  # already popped by another thread
+            self._cached_source._req.pop(self._key, None)
 
         return self._result
 

--- a/volumina/pixelpipeline/datasources/factories.py
+++ b/volumina/pixelpipeline/datasources/factories.py
@@ -20,6 +20,7 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 from functools import singledispatch
+from typing import Union, Tuple
 
 import numpy
 
@@ -105,7 +106,7 @@ def _numpy_ds(source, withShape=False):
 
 if hasLazyflow:
 
-    def _createDataSourceLazyflow(slot, withShape):
+    def _createDataSourceLazyflow(slot, withShape) -> Union[Tuple[LazyflowSource, Tuple[int]], LazyflowSource]:
         # has to handle Lazyflow source
         src = LazyflowSource(slot)
         shape = src._op5.Output.meta.shape
@@ -115,7 +116,7 @@ if hasLazyflow:
             return src
 
     @createDataSource.register(lazyflow.graph.OutputSlot)
-    def _lazyflow_out(slot, withShape=False):
+    def _lazyflow_out(slot, withShape=False) -> Union[Tuple[CacheSource, Tuple[int]], CacheSource]:
         if withShape:
             src, shape = _createDataSourceLazyflow(slot, withShape)
             return CacheSource(src), shape

--- a/volumina/pixelpipeline/datasources/factories.py
+++ b/volumina/pixelpipeline/datasources/factories.py
@@ -106,7 +106,7 @@ def _numpy_ds(source, withShape=False):
 
 if hasLazyflow:
 
-    def _createDataSourceLazyflow(slot, withShape) -> Union[Tuple[LazyflowSource, Tuple[int]], LazyflowSource]:
+    def _createDataSourceLazyflow(slot, withShape) -> Union[Tuple[LazyflowSource, Tuple[int, ...]], LazyflowSource]:
         # has to handle Lazyflow source
         src = LazyflowSource(slot)
         shape = src._op5.Output.meta.shape
@@ -116,7 +116,7 @@ if hasLazyflow:
             return src
 
     @createDataSource.register(lazyflow.graph.OutputSlot)
-    def _lazyflow_out(slot, withShape=False) -> Union[Tuple[CacheSource, Tuple[int]], CacheSource]:
+    def _lazyflow_out(slot, withShape=False) -> Union[Tuple[CacheSource, Tuple[int, ...]], CacheSource]:
         if withShape:
             src, shape = _createDataSourceLazyflow(slot, withShape)
             return CacheSource(src), shape

--- a/volumina/pixelpipeline/imagepump.py
+++ b/volumina/pixelpipeline/imagepump.py
@@ -25,6 +25,8 @@ from functools import partial
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
+from volumina.layer import Layer
+from volumina.pixelpipeline.interface import ImageSourceABC
 from volumina.pixelpipeline.slicesources import PlanarSliceSource, SyncedSliceSources, StackId
 
 
@@ -172,7 +174,7 @@ class StackedImageSources(QObject):
     def viewImageSources(self):
         return StackedImageSources.ImageSourceView(self)
 
-    def register(self, layer, imageSource):
+    def register(self, layer: Layer, imageSource: ImageSourceABC):
         if self.isRegistered(layer):
             raise Exception("StackedImageSources.register(): layer %s already registered" % str(layer))
         if layer not in self._layerStackModel:


### PR DESCRIPTION
Volumina caches requests since #255. Unfortunately this also caches requests that fail, and once a lazyflow request fails, it is permanently failed.

By dropping failed requests, failed tiles can be retried in 3D datasets - by scrolling away and back to the same view. Retrying in 2D will take more work, but also depends on this fix.

This is probably easier than reworking requests to be re-usable...

Edit/Clarification: I realised that for now this only leads to "retries" for volumina tiles whose underlying data can partially fail 😅 specifically, tiles that depend on multiple OME-Zarr chunks.