### PR TITLE
switch to qtpy - qt-api "agnostic" qt-python-bindings

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.9
     - pip
     - setuptools >=40.0
     - setuptools_scm
@@ -23,6 +23,7 @@ requirements:
     - pyqt >=5.6
     - pyqtgraph
     - qimage2ndarray
+    - qtpy
     - typing_extensions
     - vigra
     - xarray
@@ -58,7 +59,7 @@ test:
     - pytest
     - pytest-qt
     - pyqt >=5.11
-    - python 3.8.*
+    - python 3.11.*
   commands:
     - pytest .
     - volumina --help

--- a/examples/labeling.py
+++ b/examples/labeling.py
@@ -6,7 +6,7 @@ from volumina.colortables import default16_new
 from volumina.pixelpipeline.datasources import ArraySinkSource, ArraySource
 from volumina.layer import ColortableLayer, GrayscaleLayer
 
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 
 SHAPE = (1, 600, 800, 1, 1)  # volumina expects 5d txyzc
 

--- a/examples/streamingViewer.py
+++ b/examples/streamingViewer.py
@@ -29,7 +29,7 @@ from lazyflow.graph import Graph
 from lazyflow.operators.ioOperators.opStreamingH5N5Reader import OpStreamingH5N5Reader
 from lazyflow.operators import OpCompressedCache
 
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 
 f = h5py.File("raw.h5", "w")
 d = (255 * numpy.random.random((100, 200, 300))).astype(numpy.uint8)

--- a/tests/brushingmodel_test.py
+++ b/tests/brushingmodel_test.py
@@ -25,7 +25,7 @@ from builtins import range
 import unittest as ut
 import numpy as np
 import pytest
-from PyQt5.QtCore import QPointF
+from qtpy.QtCore import QPointF
 from volumina.brushingmodel import BrushingModel
 
 

--- a/tests/colortable_contextmenu_manual.py
+++ b/tests/colortable_contextmenu_manual.py
@@ -26,8 +26,8 @@
 from __future__ import division
 from __future__ import print_function
 from volumina.api import Viewer
-from PyQt5.QtGui import QColor, QKeySequence
-from PyQt5.QtWidgets import QApplication, QPushButton, QShortcut
+from qtpy.QtGui import QColor, QKeySequence
+from qtpy.QtWidgets import QApplication, QPushButton, QShortcut
 import numpy
 import h5py
 

--- a/tests/direct_layer_manual.py
+++ b/tests/direct_layer_manual.py
@@ -27,8 +27,8 @@
 #
 
 from volumina.api import Viewer
-from PyQt5.QtGui import QColor, QKeySequence
-from PyQt5.QtWidgets import QApplication, QPushButton, QShortcut
+from qtpy.QtGui import QColor, QKeySequence
+from qtpy.QtWidgets import QApplication, QPushButton, QShortcut
 import numpy
 import h5py
 

--- a/tests/imageScene2D_test.py
+++ b/tests/imageScene2D_test.py
@@ -25,8 +25,8 @@ import time
 
 import pytest
 
-from PyQt5.QtGui import QImage, QPainter
-from PyQt5.QtWidgets import QStyleOptionGraphicsItem
+from qtpy.QtGui import QImage, QPainter
+from qtpy.QtWidgets import QStyleOptionGraphicsItem
 
 from qimage2ndarray import byte_view
 import numpy as np

--- a/tests/imagepump_test.py
+++ b/tests/imagepump_test.py
@@ -20,7 +20,7 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 import unittest as ut
-from PyQt5.QtCore import QRect, QObject, QItemSelectionModel
+from qtpy.QtCore import QRect, QObject, QItemSelectionModel
 
 from volumina.layerstack import LayerStackModel
 from volumina.layer import GrayscaleLayer

--- a/tests/imagesources_test.py
+++ b/tests/imagesources_test.py
@@ -32,9 +32,9 @@ import sys
 import numpy
 
 # PyQt
-from PyQt5.QtCore import QRect
-from PyQt5.QtGui import QImage, QColor
-from PyQt5.QtWidgets import QGraphicsItem
+from qtpy.QtCore import QRect
+from qtpy.QtGui import QImage, QColor
+from qtpy.QtWidgets import QGraphicsItem
 
 import qimage2ndarray
 
@@ -530,7 +530,7 @@ class TestGraphicsItems(ut.TestCase):
 
         DEBUG = False
         if DEBUG:
-            from PyQt5.QtWidgets import QApplication, QGraphicsView, QGraphicsScene
+            from qtpy.QtWidgets import QApplication, QGraphicsView, QGraphicsScene
 
             app = QApplication([])
             scene = QGraphicsScene()

--- a/tests/layerwidget_test.py
+++ b/tests/layerwidget_test.py
@@ -25,9 +25,9 @@ import threading
 import unittest as ut
 
 import pytest
-from PyQt5.QtCore import QTimer
-from PyQt5.QtWidgets import qApp, QApplication, QWidget, QHBoxLayout
-from PyQt5.QtGui import QScreen, QGuiApplication
+from qtpy.QtCore import QTimer
+from qtpy.QtWidgets import QApplication, QWidget, QHBoxLayout
+from qtpy.QtGui import QScreen, QGuiApplication
 
 from volumina.layer import Layer
 from volumina.layerstack import LayerStackModel
@@ -93,7 +93,7 @@ class TestLayerWidget(ut.TestCase):
             traceback.print_exc()
             TestLayerWidget.errors = True
 
-        qApp.quit()
+        QApplication.instance().quit()
 
     def test_repaint_after_visible_change(self):
         self.model = LayerStackModel()

--- a/tests/lazy_test.py
+++ b/tests/lazy_test.py
@@ -38,8 +38,8 @@ if has_dependencies:
     import os
     import time
 
-    from PyQt5.QtCore import Qt
-    from PyQt5.QtGui import QImage, QPainter
+    from qtpy.QtCore import Qt
+    from qtpy.QtGui import QImage, QPainter
 
     from qimage2ndarray import byte_view
     import numpy

--- a/tests/multichannel_manual.py
+++ b/tests/multichannel_manual.py
@@ -20,7 +20,7 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 from volumina.api import Viewer
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 import numpy
 
 app = QApplication([])

--- a/tests/skeletons.py
+++ b/tests/skeletons.py
@@ -24,7 +24,7 @@
 #
 
 from volumina.api import Viewer
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 import numpy
 import h5py
 from volumina.skeletons import Skeletons, SkeletonInterpreter

--- a/tests/slicingtools_test.py
+++ b/tests/slicingtools_test.py
@@ -21,7 +21,7 @@
 ###############################################################################
 import unittest
 import volumina.slicingtools as st
-from PyQt5.QtCore import QRect
+from qtpy.QtCore import QRect
 
 
 class SlicingToolsTest(unittest.TestCase):

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 import numpy as np
-from PyQt5.QtGui import QColor, QPen
+from qtpy.QtGui import QColor, QPen
 from itertools import count
 
 from volumina import layer

--- a/tests/test_pixelpipeline/test_datasources/test_cachesource.py
+++ b/tests/test_pixelpipeline/test_datasources/test_cachesource.py
@@ -6,15 +6,15 @@ from unittest import mock
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 
 from volumina.pixelpipeline.datasources.cachesource import CacheSource
 from volumina.utility.cache import KVCache
 
 
 class DummySource(QObject):
-    isDirty = pyqtSignal(object)
-    numberOfChannelsChanged = pyqtSignal(int)
+    isDirty = Signal(object)
+    numberOfChannelsChanged = Signal(int)
 
     class _Req:
         def __init__(self, arr):

--- a/tests/test_pixelpipeline/test_imagesources.py
+++ b/tests/test_pixelpipeline/test_imagesources.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 
-from PyQt5.QtCore import QRect
+from qtpy.QtCore import QRect
 from volumina.pixelpipeline import imagesources as imsrc
 from volumina.pixelpipeline.interface import ImageSourceABC, PlanarSliceSourceABC
 

--- a/tests/test_tiling/test_tiling.py
+++ b/tests/test_tiling/test_tiling.py
@@ -26,8 +26,8 @@ import unittest as ut
 
 import numpy as np
 
-from PyQt5.QtCore import QRectF, QPoint, QRect
-from PyQt5.QtGui import QTransform
+from qtpy.QtCore import QRectF, QPoint, QRect
+from qtpy.QtGui import QTransform
 from qimage2ndarray import byte_view
 
 from volumina.tiling import TileProvider, Tiling

--- a/tests/test_utility/test_qabc.py
+++ b/tests/test_utility/test_qabc.py
@@ -2,15 +2,14 @@ from unittest import mock
 
 import pytest
 
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 from volumina.utility import qabc
 
 
 class TestQAbc:
     class IObject(qabc.QABC):
         @qabc.abstractmethod
-        def foo(self):
-            ...
+        def foo(self): ...
 
     class ISignal(qabc.QABC):
         signal = qabc.abstractsignal()
@@ -26,7 +25,7 @@ class TestQAbc:
 
     def test_implemented_signal_doesnt_raise_type_error(self):
         class MySignal(self.ISignal):
-            signal = pyqtSignal(int)
+            signal = Signal(int)
 
         MySignal()
 

--- a/volumina/__main__.py
+++ b/volumina/__main__.py
@@ -5,7 +5,7 @@ import sys
 
 import numpy
 import xarray
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 
 from volumina import __version__
 from volumina.api import Viewer

--- a/volumina/_testing/from_lazyflow.py
+++ b/volumina/_testing/from_lazyflow.py
@@ -96,8 +96,8 @@ if __name__ == "__main__":
 
     #######
     from scipy.misc import imshow
-    from PyQt5.QtCore import QTimer
-    from PyQt5.QtWidgets import QApplication, QLabel, QPixmap, QImage
+    from qtpy.QtCore import QTimer
+    from qtpy.QtWidgets import QApplication, QLabel, QPixmap, QImage
     from qimage2ndarray import gray2qimage
     #make the program quit on Ctrl+C
     import signal

--- a/volumina/_testing/labeled3d.py
+++ b/volumina/_testing/labeled3d.py
@@ -27,8 +27,8 @@ import signal
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-from PyQt5.QtCore import QRect, QPoint, Qt, QTimer
-from PyQt5.QtWidgets import QApplication, QPainter, QImage, QBrush, QPen, QColor, QBrush
+from qtpy.QtCore import QRect, QPoint, Qt, QTimer
+from qtpy.QtWidgets import QApplication, QPainter, QImage, QBrush, QPen, QColor, QBrush
 
 import sys
 import qimage2ndarray, numpy

--- a/volumina/api.py
+++ b/volumina/api.py
@@ -29,7 +29,7 @@ from volumina.layerstack import LayerStackModel
 from volumina.widgets.layerwidget import LayerWidget
 from volumina.viewer import Viewer, ClickableSegmentationLayer
 
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 import sys
 
 

--- a/volumina/brushingcontroller.py
+++ b/volumina/brushingcontroller.py
@@ -24,10 +24,10 @@ from __future__ import absolute_import
 import numpy
 from functools import partial
 
-import sip
-from PyQt5.QtCore import pyqtSignal, QObject, QEvent, QPointF, Qt, QTimer
-from PyQt5.QtGui import QPen, QBrush, QMouseEvent
-from PyQt5.QtWidgets import QApplication, QGraphicsLineItem, QUndoStack, QUndoCommand
+import qtpy.compat
+from qtpy.QtCore import Signal, QObject, QEvent, QPointF, Qt, QTimer
+from qtpy.QtGui import QPen, QBrush, QMouseEvent
+from qtpy.QtWidgets import QApplication, QGraphicsLineItem, QUndoCommand
 
 from volumina.eventswitch import InterpreterABC
 from .navigationController import NavigationInterpreter
@@ -142,7 +142,7 @@ class BrushingInterpreter(QObject, InterpreterABC):
             # after updating python to 3.9 we encountered exceptions when shutting
             #  ilastik down. Since we don't own the view or the scene, those could
             # get deleted then accessing those would raise.
-            if sip.isdeleted(view):
+            if not qtpy.compat.isalive(view):
                 continue
             if not (view.scene() and view.scene().allow_brushing):
                 return self._navIntr.eventFilter(watched, event)
@@ -295,7 +295,7 @@ class BrushingInterpreter(QObject, InterpreterABC):
 
 
 class BrushingController(QObject):
-    wroteToSink = pyqtSignal()
+    wroteToSink = Signal()
 
     def __init__(self, brushingModel, positionModel, dataSink, *, undoStack):
         QObject.__init__(self, parent=None)

--- a/volumina/brushingmodel.py
+++ b/volumina/brushingmodel.py
@@ -21,9 +21,9 @@
 ###############################################################################
 #!/usr/bin/env python
 from __future__ import division
-from PyQt5.QtCore import pyqtSignal, QObject, Qt, QSize, QPointF, QRectF, QRect, QPoint, QSizeF
-from PyQt5.QtWidgets import QGraphicsScene, QGraphicsLineItem
-from PyQt5.QtGui import QPen, QColor, QImage, QPainter, QBrush
+from qtpy.QtCore import Signal, QObject, Qt, QSize, QPointF, QRectF, QRect, QPoint, QSizeF
+from qtpy.QtWidgets import QGraphicsScene, QGraphicsLineItem
+from qtpy.QtGui import QPen, QColor, QImage, QPainter, QBrush
 
 import numpy, math
 import qimage2ndarray
@@ -34,10 +34,10 @@ import qimage2ndarray
 
 
 class BrushingModel(QObject):
-    brushSizeChanged = pyqtSignal(int)
-    brushColorChanged = pyqtSignal(QColor)
-    brushStrokeAvailable = pyqtSignal(QPointF, object)
-    drawnNumberChanged = pyqtSignal(int)
+    brushSizeChanged = Signal(int)
+    brushColorChanged = Signal(QColor)
+    brushStrokeAvailable = Signal(QPointF, object)
+    drawnNumberChanged = Signal(int)
 
     minBrushSize = 1
     maxBrushSize = 61

--- a/volumina/colortables.py
+++ b/volumina/colortables.py
@@ -37,7 +37,7 @@ import itertools
 import numpy as np
 from past.utils import old_div
 
-from PyQt5.QtGui import QColor
+from qtpy.QtGui import QColor
 
 
 def matplotlib_to_qt4_colortable(cmap_name, N, asLong=True):
@@ -447,7 +447,7 @@ def create_random_16bit():
 
 if __name__ == "__main__":
     from volumina.api import *
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     from volumina.pixelpipeline.datasourcefactories import *
 
     app = QApplication(sys.argv)

--- a/volumina/croppingMarkers.py
+++ b/volumina/croppingMarkers.py
@@ -19,18 +19,18 @@ from builtins import range
 from past.utils import old_div
 import copy
 import contextlib
-from PyQt5.QtCore import pyqtSignal, Qt, QObject, QRectF, QPointF
-from PyQt5.QtGui import QPen, QCursor, QBrush, QColor
-from PyQt5.QtWidgets import QGraphicsItem, QApplication
+from qtpy.QtCore import Signal, Qt, QObject, QRectF, QPointF
+from qtpy.QtGui import QPen, QCursor, QBrush, QColor
+from qtpy.QtWidgets import QGraphicsItem, QApplication
 
 
 class CropExtentsModel(QObject):
-    changed = pyqtSignal(object)  # list of start/stop coords indexed by axis
+    changed = Signal(object)  # list of start/stop coords indexed by axis
     # Note: There is no required ordering for start/stop
     #       (i.e. start could be greater than stop)
-    colorChanged = pyqtSignal(QColor)
-    editableChanged = pyqtSignal(bool)
-    mouseRelease = pyqtSignal()
+    colorChanged = Signal(QColor)
+    editableChanged = Signal(bool)
+    mouseRelease = Signal()
 
     @property
     def editable(self):
@@ -262,10 +262,10 @@ class CroppingMarkers(QGraphicsItem):
 
     def mousePressEvent(self, event):
         """
-            Moving a corner or line, in this priority order.
-            The line(s) indices that started the move are stored in:
-            self.mouseMoveStartH and
-            self.mouseMoveStartV
+        Moving a corner or line, in this priority order.
+        The line(s) indices that started the move are stored in:
+        self.mouseMoveStartH and
+        self.mouseMoveStartV
         """
         if self.crop_extents_model._editable:
             position = self.scene().data2scene.map(event.scenePos())
@@ -570,7 +570,7 @@ class CropLine(QGraphicsItem):
 
     def mouseMoveEvent(self, event):
         """
-            Moving a line.
+        Moving a line.
         """
         if self._parent.crop_extents_model._editable:
             new_pos = self.scene().data2scene.map(event.scenePos())
@@ -625,7 +625,7 @@ class CropLine(QGraphicsItem):
 
     def mousePressEvent(self, event):
         """
-            Selecting a line.
+        Selecting a line.
         """
 
         if self._parent.crop_extents_model._editable:

--- a/volumina/crossHairCursor.py
+++ b/volumina/crossHairCursor.py
@@ -48,9 +48,9 @@
 #    authors and should not be interpreted as representing official policies, either expressed
 #    or implied, of their employers.
 
-from PyQt5.QtCore import Qt, QPointF, QRectF
-from PyQt5.QtGui import QPen
-from PyQt5.QtWidgets import QGraphicsItem
+from qtpy.QtCore import Qt, QPointF, QRectF
+from qtpy.QtGui import QPen
+from qtpy.QtWidgets import QGraphicsItem
 
 # *******************************************************************************
 # C r o s s H a i r C u r s o r                                                *
@@ -139,7 +139,7 @@ class CrossHairCursor(QGraphicsItem):
 
     def showXYPosition(self, x, y):
         """mark the (x,y) position by displaying a cross hair cursor
-           including a circle indicating the current brush size"""
+        including a circle indicating the current brush size"""
         self.setVisible(True)
         self.mode = self.modeXYPosition
         self.setPos(x, y)

--- a/volumina/eventswitch.py
+++ b/volumina/eventswitch.py
@@ -22,8 +22,8 @@
 
 from typing import Iterable
 
-from PyQt5.QtCore import QEvent, QObject
-from PyQt5.QtWidgets import QGraphicsView
+from qtpy.QtCore import QEvent, QObject
+from qtpy.QtWidgets import QGraphicsView
 from volumina.utility.qabc import QABC, abstractmethod
 
 
@@ -38,7 +38,7 @@ class InterpreterABC(QABC):
 
     @abstractmethod
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
-        """Necessary to act as a Qt event filter. """
+        """Necessary to act as a Qt event filter."""
 
 
 class EventSwitch(QObject):

--- a/volumina/icons_rc.py
+++ b/volumina/icons_rc.py
@@ -29,7 +29,7 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt5 import QtCore
+from qtpy import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x03\xc0\

--- a/volumina/imageScene2D.py
+++ b/volumina/imageScene2D.py
@@ -25,8 +25,8 @@ from builtins import range
 from past.utils import old_div
 import numpy, math
 
-from PyQt5.QtCore import QRect, QRectF, QPointF, Qt, QSizeF, QLineF, QObject, pyqtSignal, QTimer
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import QRect, QRectF, QPointF, Qt, QSizeF, QLineF, QObject, Signal, QTimer
+from qtpy.QtWidgets import (
     QGraphicsScene,
     QGraphicsItem,
     QGraphicsItemGroup,
@@ -35,7 +35,7 @@ from PyQt5.QtWidgets import (
     QGraphicsPolygonItem,
     QGraphicsRectItem,
 )
-from PyQt5.QtGui import QTransform, QPen, QColor, QBrush, QPolygonF, QPainter, QPainterPath
+from qtpy.QtGui import QTransform, QPen, QColor, QBrush, QPolygonF, QPainter, QPainterPath
 
 from volumina.tiling import Tiling, TileProvider
 from volumina.layerstack import LayerStackModel
@@ -44,6 +44,7 @@ from volumina.pixelpipeline.imagepump import StackedImageSources
 import datetime
 import threading
 from collections import defaultdict
+
 
 # *******************************************************************************
 # D i r t y I n d i c a t o r                                                  *
@@ -127,8 +128,8 @@ class ImageScene2D(QGraphicsScene):
     an overlay stack, together with a 2D cursor.
     """
 
-    axesChanged = pyqtSignal(int, bool)
-    dirtyChanged = pyqtSignal()
+    axesChanged = Signal(int, bool)
+    dirtyChanged = Signal()
 
     @property
     def is_swapped(self):
@@ -214,7 +215,7 @@ class ImageScene2D(QGraphicsScene):
         self.axesChanged.emit(self._rotation, self._swapped)
 
     def rot90(self, direction):
-        """ direction: left ==> -1, right ==> +1"""
+        """direction: left ==> -1, right ==> +1"""
         assert direction in [-1, 1]
         self._rotation = (self._rotation + direction) % 4
         self._newAxes()

--- a/volumina/imageView2D.py
+++ b/volumina/imageView2D.py
@@ -19,9 +19,9 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from PyQt5.QtCore import QPoint, QPointF, QTimer, pyqtSignal, Qt
-from PyQt5.QtGui import QCursor, QPainter
-from PyQt5.QtWidgets import QGraphicsView, QVBoxLayout, QApplication, QMessageBox, QOpenGLWidget
+from qtpy.QtCore import QPoint, QPointF, QTimer, Signal, Qt
+from qtpy.QtGui import QCursor, QPainter
+from qtpy.QtWidgets import QGraphicsView, QVBoxLayout, QApplication, QMessageBox, QOpenGLWidget
 
 import numpy
 
@@ -38,7 +38,7 @@ import volumina.config
 
 
 class ImageView2D(QGraphicsView):
-    focusChanged = pyqtSignal()
+    focusChanged = Signal()
 
     """
     Shows a ImageScene2D to the user and allows for interactive
@@ -238,7 +238,7 @@ class ImageView2D(QGraphicsView):
         return QPointF(x, y)
 
     def _qBound(self, minVal, current, maxVal):
-        """PyQt5 does not wrap the qBound function from Qt's global namespace
+        """qtpy does not wrap the qBound function from Qt's global namespace
         This is equivalent."""
         return max(min(current, maxVal), minVal)
 
@@ -354,7 +354,7 @@ if __name__ == "__main__":
     import signal
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    from PyQt5.QtWidgets import QMainWindow
+    from qtpy.QtWidgets import QMainWindow
     from scipy.misc import lena
 
     def checkerboard(shape, squareSize):

--- a/volumina/interpreter.py
+++ b/volumina/interpreter.py
@@ -20,15 +20,15 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 
-from PyQt5.QtCore import QObject, pyqtSignal, QEvent, Qt, QPoint
+from qtpy.QtCore import QObject, Signal, QEvent, Qt, QPoint
 
 from volumina.eventswitch import InterpreterABC
 
 
 class ClickReportingInterpreter(QObject, InterpreterABC):
-    rightClickReceived = pyqtSignal(object, QPoint)  # list of indexes, global window coordinate of click
-    leftClickReceived = pyqtSignal(object, QPoint)  # ditto
-    toolTipReceived = pyqtSignal(object, QPoint)
+    rightClickReceived = Signal(object, QPoint)  # list of indexes, global window coordinate of click
+    leftClickReceived = Signal(object, QPoint)  # ditto
+    toolTipReceived = Signal(object, QPoint)
 
     def __init__(self, navigationInterpreter, positionModel):
         QObject.__init__(self)
@@ -72,16 +72,16 @@ class ClickReportingInterpreter(QObject, InterpreterABC):
 
 class ClickInterpreter(QObject, InterpreterABC):
     """Intercepts mouse clicks (right clicks by default) and double
-       click events on a layer and calls a given functor with the
-       clicked position.
+    click events on a layer and calls a given functor with the
+    clicked position.
 
     """
 
     def __init__(self, editor, layer, onClickFunctor, parent=None, right=True, double=True):
-        """ editor:         VolumeEditor object
-            layer:          Layer instance on which was clicked
-            onClickFunctor: a function f(layer, position5D, windowPosition)
-            right: If True, intercept right clicks, otherwise intercept left clicks.
+        """editor:         VolumeEditor object
+        layer:          Layer instance on which was clicked
+        onClickFunctor: a function f(layer, position5D, windowPosition)
+        right: If True, intercept right clicks, otherwise intercept left clicks.
         """
         QObject.__init__(self, parent)
         self.baseInterpret = editor.navInterpret

--- a/volumina/layer.py
+++ b/volumina/layer.py
@@ -23,8 +23,8 @@ from builtins import range
 import colorsys
 import numpy
 
-from PyQt5.QtCore import Qt, QObject, pyqtSignal, QTimer
-from PyQt5.QtGui import QColor, QPen
+from qtpy.QtCore import Qt, QObject, Signal, QTimer
+from qtpy.QtGui import QColor, QPen
 
 from volumina.interpreter import ClickInterpreter
 from volumina.pixelpipeline.slicesources import PlanarSliceSource
@@ -55,13 +55,13 @@ class Layer(QObject):
 
     """changed is emitted whenever one of the more specialized
     somethingChanged signals is emitted."""
-    changed = pyqtSignal()
+    changed = Signal()
 
-    visibleChanged = pyqtSignal(bool)
-    opacityChanged = pyqtSignal(float)
-    nameChanged = pyqtSignal(object)
-    channelChanged = pyqtSignal(int)
-    numberOfChannelsChanged = pyqtSignal(int)
+    visibleChanged = Signal(bool)
+    opacityChanged = Signal(float)
+    nameChanged = Signal(object)
+    channelChanged = Signal(int)
+    numberOfChannelsChanged = Signal(int)
 
     @property
     def normalize(self):
@@ -279,7 +279,7 @@ class NormalizableLayer(Layer):
     int -- upper threshold
     """
 
-    normalizeChanged = pyqtSignal()
+    normalizeChanged = Signal()
 
     @property
     def normalize(self):
@@ -373,7 +373,7 @@ class GrayscaleLayer(NormalizableLayer):
         return self._window_leveling != other_layer._window_leveling
 
     def __init__(self, datasource, normalize=None, direct=False, window_leveling=False):
-        assert isinstance(datasource, DataSourceABC)
+        # assert isinstance(datasource, DataSourceABC)
         super().__init__([datasource], normalize, direct=direct)
         self._window_leveling = window_leveling
 
@@ -388,7 +388,7 @@ class GrayscaleLayer(NormalizableLayer):
 
 
 class AlphaModulatedLayer(NormalizableLayer):
-    tintColorChanged = pyqtSignal()
+    tintColorChanged = Signal()
 
     @property
     def tintColor(self):
@@ -447,7 +447,7 @@ def generateRandomColors(M=256, colormodel="hsv", clamp=None, zeroIsTransparent=
 
 
 class ColortableLayer(NormalizableLayer):
-    colorTableChanged = pyqtSignal()
+    colorTableChanged = Signal()
 
     @property
     def colorTable(self):
@@ -502,7 +502,7 @@ class ColortableLayer(NormalizableLayer):
 
 
 class ClickableColortableLayer(ClickableLayer):
-    colorTableChanged = pyqtSignal()
+    colorTableChanged = Signal()
 
     def __init__(self, editor, clickFunctor, datasource, colorTable, direct=False, right=True):
         assert isinstance(datasource, DataSourceABC)
@@ -609,7 +609,7 @@ class SegmentationEdgesLayer(Layer):
     (See imagesources.SegmentationEdgesItem.)
     """
 
-    hoverIdChanged = pyqtSignal(object)
+    hoverIdChanged = Signal(object)
 
     DEFAULT_PEN = QPen()
     DEFAULT_PEN.setCosmetic(True)
@@ -670,7 +670,7 @@ class LabelableSegmentationEdgesLayer(SegmentationEdgesLayer):
     Shows a set of user-labeled edges.
     """
 
-    labelsChanged = pyqtSignal(dict)  # { id_pair, label_class }
+    labelsChanged = Signal(dict)  # { id_pair, label_class }
 
     def __init__(
         self, datasource, label_class_pens, initial_labels={}, delay_ms=100, *, isClickable=True, isHoverable=True

--- a/volumina/layerstack.py
+++ b/volumina/layerstack.py
@@ -20,20 +20,20 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 import functools
-from PyQt5.QtCore import QAbstractListModel, QItemSelectionModel, pyqtSignal, QModelIndex, Qt, QTimer
+from qtpy.QtCore import QAbstractListModel, QItemSelectionModel, Signal, QModelIndex, Qt, QTimer
 
 from volumina.layer import Layer
 
 
 class LayerStackModel(QAbstractListModel):
-    canMoveSelectedUp = pyqtSignal("bool")
-    canMoveSelectedDown = pyqtSignal("bool")
-    canDeleteSelected = pyqtSignal("bool")
+    canMoveSelectedUp = Signal("bool")
+    canMoveSelectedDown = Signal("bool")
+    canDeleteSelected = Signal("bool")
 
-    orderChanged = pyqtSignal()
-    layerAdded = pyqtSignal(Layer, int)  # is now in row
-    layerRemoved = pyqtSignal(Layer, int)  # was in row
-    stackCleared = pyqtSignal()
+    orderChanged = Signal()
+    layerAdded = Signal(Layer, int)  # is now in row
+    layerRemoved = Signal(Layer, int)  # was in row
+    stackCleared = Signal()
 
     def __init__(self, parent=None):
         QAbstractListModel.__init__(self, parent)
@@ -317,7 +317,7 @@ class LayerStackModel(QAbstractListModel):
         """Select layer and move it to the top or bottom of the stack.
 
         Layer goes to the top unless it's already there.
-        Top layer goes to the bottom.        
+        Top layer goes to the bottom.
         """
         index = self.layerIndex(layer)
         self.selectRow(index)

--- a/volumina/layerwidget_plugin.py
+++ b/volumina/layerwidget_plugin.py
@@ -19,8 +19,8 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from PyQt5.QtDesigner import QPyDesignerCustomWidgetPlugin
-from PyQt5.QtWidgets import QPixmap, QIcon, QColor
+from qtpy.QtDesigner import QPyDesignerCustomWidgetPlugin
+from qtpy.QtWidgets import QPixmap, QIcon, QColor
 
 from volumina.widgets.layerwidget import LayerWidget
 from volumina.layerstack import LayerStackModel, Layer

--- a/volumina/navigationController.py
+++ b/volumina/navigationController.py
@@ -25,8 +25,8 @@ import sys
 from functools import partial
 
 import volumina
-from PyQt5.QtCore import QEvent, QObject, QPointF, Qt, QTimer, pyqtSignal
-from PyQt5.QtGui import QColor, QCursor
+from qtpy.QtCore import QEvent, QObject, QPointF, Qt, QTimer, Signal
+from qtpy.QtGui import QColor, QCursor
 from volumina.eventswitch import InterpreterABC
 from volumina.imageScene2D import DirtyIndicator
 from volumina.sliceIntersectionMarker import SliceIntersectionMarker
@@ -284,7 +284,7 @@ class NavigationController(QObject):
     enableNavigation -- whether the position is allowed to be changed
     """
 
-    navigationEnabled = pyqtSignal(bool)
+    navigationEnabled = Signal(bool)
 
     @property
     def axisColors(self):

--- a/volumina/patchAccessor.py
+++ b/volumina/patchAccessor.py
@@ -19,7 +19,7 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from PyQt5.QtCore import QPointF, QRectF
+from qtpy.QtCore import QPointF, QRectF
 
 import numpy
 

--- a/volumina/pixelpipeline/datasources/arraysource.py
+++ b/volumina/pixelpipeline/datasources/arraysource.py
@@ -1,5 +1,5 @@
 import numpy as np
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 
 from volumina.pixelpipeline.interface import DataSourceABC, RequestABC
 from volumina.slicingtools import is_pure_slicing, index2slice
@@ -24,8 +24,8 @@ class ArrayRequest(RequestABC):
 
 
 class ArraySource(QObject, DataSourceABC):
-    isDirty = pyqtSignal(object)
-    numberOfChannelsChanged = pyqtSignal(int)  # Never emitted
+    isDirty = Signal(object)
+    numberOfChannelsChanged = Signal(int)  # Never emitted
 
     def __init__(self, array):
         super(ArraySource, self).__init__()
@@ -88,7 +88,7 @@ class RelabelingArraySource(ArraySource):
     """Applies a relabeling to each request before passing it on
     Currently, it casts everything to uint8, so be careful."""
 
-    isDirty = pyqtSignal(object)
+    isDirty = Signal(object)
 
     def __init__(self, array):
         super(RelabelingArraySource, self).__init__(array)

--- a/volumina/pixelpipeline/datasources/cachesource.py
+++ b/volumina/pixelpipeline/datasources/cachesource.py
@@ -4,7 +4,7 @@ import sys
 import uuid
 from typing import Union
 
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 
 from volumina.pixelpipeline.interface import DataSourceABC
 from volumina.slicingtools import is_pure_slicing
@@ -65,8 +65,8 @@ class _CachedRequest:
 
 
 class CacheSource(QObject, DataSourceABC):
-    isDirty = pyqtSignal(object)
-    numberOfChannelsChanged = pyqtSignal(int)
+    isDirty = Signal(object)
+    numberOfChannelsChanged = Signal(int)
 
     def __init__(self, source: "LazyflowSource", cache=ARRAY_CACHE):
         super().__init__()

--- a/volumina/pixelpipeline/datasources/constantsource.py
+++ b/volumina/pixelpipeline/datasources/constantsource.py
@@ -1,5 +1,5 @@
 import numpy as np
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 
 from volumina.slicingtools import is_pure_slicing, slicing2shape, is_bounded, sl
 from volumina.pixelpipeline.interface import DataSourceABC, RequestABC
@@ -23,8 +23,8 @@ class ConstantRequest(RequestABC):
 
 
 class ConstantSource(QObject, DataSourceABC):
-    isDirty = pyqtSignal(object)
-    numberOfChannelsChanged = pyqtSignal(int)  # Never emitted
+    isDirty = Signal(object)
+    numberOfChannelsChanged = Signal(int)  # Never emitted
 
     @property
     def constant(self):

--- a/volumina/pixelpipeline/datasources/halosource.py
+++ b/volumina/pixelpipeline/datasources/halosource.py
@@ -1,4 +1,4 @@
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 
 from volumina.pixelpipeline.interface import DataSourceABC
 
@@ -10,8 +10,8 @@ class HaloAdjustedDataSource(QObject, DataSourceABC):
     and forwards the expanded request to the underlying datasouce object.
     """
 
-    isDirty = pyqtSignal(object)
-    numberOfChannelsChanged = pyqtSignal(int)
+    isDirty = Signal(object)
+    numberOfChannelsChanged = Signal(int)
 
     def __init__(self, rawSource, halo_start_delta, halo_stop_delta, parent=None):
         """

--- a/volumina/pixelpipeline/datasources/lazyflowsource.py
+++ b/volumina/pixelpipeline/datasources/lazyflowsource.py
@@ -4,7 +4,7 @@ import weakref
 from functools import wraps, partial
 
 import numpy as np
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 from future.utils import raise_with_traceback
 from lazyflow.graph import Slot
 from lazyflow.operators import opReorderAxes
@@ -90,8 +90,8 @@ def weakref_setDirtyLF(wref, *args, **kwargs):
 
 
 class LazyflowSource(QObject, DataSourceABC):
-    isDirty = pyqtSignal(object)
-    numberOfChannelsChanged = pyqtSignal(int)
+    isDirty = Signal(object)
+    numberOfChannelsChanged = Signal(int)
 
     @property
     def dataSlot(self):

--- a/volumina/pixelpipeline/datasources/minmaxsource.py
+++ b/volumina/pixelpipeline/datasources/minmaxsource.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 import numpy as np
-from PyQt5.QtCore import QObject, pyqtSignal, QTimer
+from qtpy.QtCore import QObject, Signal, QTimer
 
 from volumina.pixelpipeline.interface import DataSourceABC, RequestABC
 from volumina.slicingtools import sl
@@ -28,14 +28,14 @@ class MinMaxSource(QObject, DataSourceABC):
     A datasource that serves as a normalizing decorator for other datasources.
     """
 
-    isDirty = pyqtSignal(object)
-    boundsChanged = pyqtSignal(
+    isDirty = Signal(object)
+    boundsChanged = Signal(
         object
     )  # When a new min/max is discovered in the result of a request, this signal is fired with the new (dmin, dmax)
-    numberOfChannelsChanged = pyqtSignal(int)
+    numberOfChannelsChanged = Signal(int)
 
     _delayedBoundsChange = (
-        pyqtSignal()
+        Signal()
     )  # Internal use only.  Allows non-main threads to start the delayedDirtySignal timer.
 
     def __init__(self, rawSource, parent=None):

--- a/volumina/pixelpipeline/imagepump.py
+++ b/volumina/pixelpipeline/imagepump.py
@@ -23,7 +23,7 @@
 from builtins import range
 from functools import partial
 
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 
 from volumina.layer import Layer
 from volumina.pixelpipeline.interface import ImageSourceABC
@@ -51,12 +51,12 @@ class StackedImageSources(QObject):
 
     """
 
-    layerDirty = pyqtSignal(object, object)
-    visibleChanged = pyqtSignal(object, bool)
-    opacityChanged = pyqtSignal(object, float)
-    sizeChanged = pyqtSignal()
-    orderChanged = pyqtSignal()
-    stackIdChanged = pyqtSignal(object, object)  # old id, new id
+    layerDirty = Signal(object, object)
+    visibleChanged = Signal(object, bool)
+    opacityChanged = Signal(object, float)
+    sizeChanged = Signal()
+    orderChanged = Signal()
+    stackIdChanged = Signal(object, object)  # old id, new id
 
     @property
     def stackId(self) -> StackId:

--- a/volumina/pixelpipeline/imagesources/_base.py
+++ b/volumina/pixelpipeline/imagesources/_base.py
@@ -1,7 +1,7 @@
 import functools
 
-from PyQt5.QtCore import QObject, QRect, pyqtSignal
-from PyQt5.QtGui import QImage
+from qtpy.QtCore import QObject, QRect, Signal
+from qtpy.QtGui import QImage
 
 from volumina import config
 from volumina.pixelpipeline.interface import ImageSourceABC
@@ -17,7 +17,7 @@ class ImageSource(QObject, ImageSourceABC):
 
     """
 
-    isDirty = pyqtSignal(QRect)
+    isDirty = Signal(QRect)
 
     def __init__(self, name, guarantees_opaqueness=False, parent=None, direct=False):
         """direct: whether this request will be computed synchronously in the GUI thread (direct=True)

--- a/volumina/pixelpipeline/imagesources/alphamodulated.py
+++ b/volumina/pixelpipeline/imagesources/alphamodulated.py
@@ -2,8 +2,8 @@ import logging
 import time
 
 import numpy as np
-from PyQt5.QtCore import QRect
-from PyQt5.QtGui import QImage
+from qtpy.QtCore import QRect
+from qtpy.QtGui import QImage
 from qimage2ndarray import array2qimage, byte_view
 
 from volumina.pixelpipeline.interface import PlanarSliceSourceABC, RequestABC

--- a/volumina/pixelpipeline/imagesources/colortable.py
+++ b/volumina/pixelpipeline/imagesources/colortable.py
@@ -4,8 +4,8 @@ import warnings
 
 import numpy as np
 from past.utils import old_div
-from PyQt5.QtCore import QRect
-from PyQt5.QtGui import QColor, QImage
+from qtpy.QtCore import QRect
+from qtpy.QtGui import QColor, QImage
 from qimage2ndarray import array2qimage, byte_view
 
 from volumina.pixelpipeline.interface import PlanarSliceSourceABC, RequestABC
@@ -28,7 +28,7 @@ class ColortableImageSource(ImageSource):
     logger = logging.getLogger(loggingName)
 
     def __init__(self, arraySource2D, layer):
-        """ colorTable: a list of QRgba values """
+        """colorTable: a list of QRgba values"""
 
         assert isinstance(arraySource2D, PlanarSliceSourceABC), "wrong type: %s" % str(type(arraySource2D))
         super(ColortableImageSource, self).__init__(layer.name, direct=layer.direct)
@@ -101,11 +101,11 @@ class ColortableImageRequest(RequestABC):
             scale = old_div((len(self._colorTable) - 1), float(nmax - nmin + 1e-35))  # if max==min
             if scale != 1.0:
                 a = a * scale
-            if len(self._colorTable) <= 2 ** 8:
+            if len(self._colorTable) <= 2**8:
                 a = np.asanyarray(a, dtype=np.uint8)
-            elif len(self._colorTable) <= 2 ** 16:
+            elif len(self._colorTable) <= 2**16:
                 a = np.asanyarray(a, dtype=np.uint16)
-            elif len(self._colorTable) <= 2 ** 32:
+            elif len(self._colorTable) <= 2**32:
                 a = np.asanyarray(a, dtype=np.uint32)
 
         # Use vigra if possible (much faster)

--- a/volumina/pixelpipeline/imagesources/dummy.py
+++ b/volumina/pixelpipeline/imagesources/dummy.py
@@ -1,9 +1,9 @@
 import logging
 from contextlib import contextmanager
 
-from PyQt5.QtCore import QRect, QRectF, QSize, Qt
-from PyQt5.QtGui import QColor, QImage, QPen
-from PyQt5.QtWidgets import QGraphicsItem, QGraphicsLineItem
+from qtpy.QtCore import QRect, QRectF, QSize, Qt
+from qtpy.QtGui import QColor, QImage, QPen
+from qtpy.QtWidgets import QGraphicsItem, QGraphicsLineItem
 
 from volumina.pixelpipeline.interface import RequestABC
 from volumina.slicingtools import rect2slicing
@@ -94,7 +94,7 @@ class DummyRasterRequest(RequestABC):
         if array_data.handedness_switched:  # array_data should be of type slicingtools.ProjectedArray
             rectf = QRectF(rectf.height(), rectf.width())
 
-        from PyQt5.QtWidgets import QPainter
+        from qtpy.QtWidgets import QPainter
 
         img = QImage(QSize(self.rectf.width(), self.rectf.height()), QImage.Format_ARGB32_Premultiplied)
         img.fill(0xFFFFFFFF)

--- a/volumina/pixelpipeline/imagesources/grayscale.py
+++ b/volumina/pixelpipeline/imagesources/grayscale.py
@@ -4,8 +4,8 @@ import time
 import warnings
 
 import numpy as np
-from PyQt5.QtCore import QRect
-from PyQt5.QtGui import QImage
+from qtpy.QtCore import QRect
+from qtpy.QtGui import QImage
 from qimage2ndarray import byte_view, gray2qimage
 
 from volumina.pixelpipeline.interface import PlanarSliceSourceABC, RequestABC

--- a/volumina/pixelpipeline/imagesources/random.py
+++ b/volumina/pixelpipeline/imagesources/random.py
@@ -1,8 +1,8 @@
 import logging
 
 import numpy as np
-from PyQt5.QtCore import QRect
-from PyQt5.QtGui import QImage
+from qtpy.QtCore import QRect
+from qtpy.QtGui import QImage
 from qimage2ndarray import gray2qimage
 
 from volumina.pixelpipeline.interface import RequestABC

--- a/volumina/pixelpipeline/imagesources/rgba.py
+++ b/volumina/pixelpipeline/imagesources/rgba.py
@@ -1,8 +1,8 @@
 import logging
 
 import numpy as np
-from PyQt5.QtCore import QRect
-from PyQt5.QtGui import QImage
+from qtpy.QtCore import QRect
+from qtpy.QtGui import QImage
 from qimage2ndarray import array2qimage
 
 from volumina.pixelpipeline.interface import PlanarSliceSourceABC, RequestABC

--- a/volumina/pixelpipeline/imagesources/segmentationedges.py
+++ b/volumina/pixelpipeline/imagesources/segmentationedges.py
@@ -21,7 +21,7 @@
 ###############################################################################
 import logging
 
-from PyQt5.QtCore import QRect
+from qtpy.QtCore import QRect
 
 from volumina.pixelpipeline.interface import RequestABC
 from volumina.slicingtools import rect2slicing

--- a/volumina/pixelpipeline/interface.py
+++ b/volumina/pixelpipeline/interface.py
@@ -24,7 +24,7 @@ from abc import ABCMeta, ABC, abstractmethod, abstractproperty
 from typing import Optional
 
 import numpy as np
-from PyQt5.QtCore import pyqtSignal
+from qtpy.QtCore import Signal
 
 from volumina.utility.qabc import QABC, abstractsignal
 
@@ -88,25 +88,19 @@ class DataSourceABC(QABC):
     numberOfChannelsChanged = abstractsignal(int)
 
     @abstractproperty
-    def numberOfChannels(self) -> int:
-        ...
+    def numberOfChannels(self) -> int: ...
 
     @abstractmethod
-    def request(self, slicing) -> RequestABC:
-        ...
+    def request(self, slicing) -> RequestABC: ...
 
     @abstractmethod
-    def dtype(self):
-        ...
+    def dtype(self): ...
 
     @abstractmethod
-    def __eq__(self, other: DataSourceABC):
-        ...
+    def __eq__(self, other: DataSourceABC): ...
 
     @abstractmethod
-    def __ne__(self, other: DataSourceABC):
-        ...
+    def __ne__(self, other: DataSourceABC): ...
 
     @abstractmethod
-    def clean_up(self) -> None:
-        ...
+    def clean_up(self) -> None: ...

--- a/volumina/pixelpipeline/slicesources.py
+++ b/volumina/pixelpipeline/slicesources.py
@@ -22,7 +22,7 @@
 import logging
 from typing import Tuple, Optional, Set
 
-from PyQt5.QtCore import QObject, pyqtSignal
+from qtpy.QtCore import QObject, Signal
 
 from volumina.config import CONFIG
 from volumina.slicingtools import SliceProjection, is_pure_slicing
@@ -68,9 +68,9 @@ class PlanarSliceRequest(RequestABC):
 
 
 class PlanarSliceSource(QObject, PlanarSliceSourceABC):
-    isDirty = pyqtSignal(object)
-    throughChanged = pyqtSignal(tuple, tuple)  # old, new
-    idChanged = pyqtSignal(object, object)  # old, new
+    isDirty = Signal(object)
+    throughChanged = Signal(tuple, tuple)  # old, new
+    idChanged = Signal(object, object)  # old, new
 
     @property
     def id(self):
@@ -165,8 +165,8 @@ StackId = Tuple[Optional["SyncedSliceSources"], Tuple[Tuple[int, int], ...]]
 
 
 class SyncedSliceSources(QObject):
-    throughChanged = pyqtSignal(tuple, tuple)  # old , new
-    idChanged = pyqtSignal(object, object)
+    throughChanged = Signal(tuple, tuple)  # old , new
+    idChanged = Signal(object, object)
 
     @property
     def id(self) -> StackId:

--- a/volumina/positionModel.py
+++ b/volumina/positionModel.py
@@ -21,7 +21,7 @@
 ###############################################################################
 import numpy
 from functools import partial
-from PyQt5.QtCore import QObject, pyqtSignal, QTimer
+from qtpy.QtCore import QObject, Signal, QTimer
 
 # *******************************************************************************
 # P o s i t i o n M o d e l                                                    *
@@ -39,11 +39,11 @@ class PositionModel(QObject):
     viewer with a mouse.
     """
 
-    timeChanged = pyqtSignal(int)
-    channelChanged = pyqtSignal(int)
-    cursorPositionChanged = pyqtSignal(object, object)
-    slicingPositionChanged = pyqtSignal(object, object)
-    slicingPositionSettled = pyqtSignal(bool)
+    timeChanged = Signal(int)
+    channelChanged = Signal(int)
+    cursorPositionChanged = Signal(object, object)
+    slicingPositionChanged = Signal(object, object)
+    slicingPositionSettled = Signal(bool)
 
     # When the user does not scroll through the stack for more than 300 ms,
     # we call the position 'settled', and slicingPositionSettled will be

--- a/volumina/quadsplitter.py
+++ b/volumina/quadsplitter.py
@@ -23,12 +23,12 @@
 from __future__ import division
 from builtins import range
 import sys
-from PyQt5.QtCore import Qt, pyqtSignal, QEvent, QTimer
-from PyQt5.QtWidgets import QSizePolicy, QWidget, QVBoxLayout, QSplitter, QApplication
+from qtpy.QtCore import Qt, Signal, QEvent, QTimer
+from qtpy.QtWidgets import QSizePolicy, QWidget, QVBoxLayout, QSplitter, QApplication
 
 
 class ImageView2DFloatingWindow(QWidget):
-    onCloseClick = pyqtSignal()
+    onCloseClick = Signal()
 
     def __init__(self):
         QWidget.__init__(self)
@@ -39,9 +39,9 @@ class ImageView2DFloatingWindow(QWidget):
 
 
 class ImageView2DDockWidget(QWidget):
-    onDockButtonClicked = pyqtSignal()
-    onMaxButtonClicked = pyqtSignal()
-    onMinButtonClicked = pyqtSignal()
+    onDockButtonClicked = Signal()
+    onMaxButtonClicked = Signal()
+    onMinButtonClicked = Signal()
 
     def __init__(self, graphicsView):
         QWidget.__init__(self)

--- a/volumina/skeletons/qGraphicsSkeletonNode.py
+++ b/volumina/skeletons/qGraphicsSkeletonNode.py
@@ -23,9 +23,9 @@ from __future__ import division
 # 		   http://ilastik.org/license/
 ###############################################################################
 from past.utils import old_div
-from PyQt5.QtCore import QPointF, Qt, QRectF
-from PyQt5.QtWidgets import QGraphicsRectItem, QGraphicsItem, QMenu
-from PyQt5.QtGui import QPen, QBrush, QColor
+from qtpy.QtCore import QPointF, Qt, QRectF
+from qtpy.QtWidgets import QGraphicsRectItem, QGraphicsItem, QMenu
+from qtpy.QtGui import QPen, QBrush, QColor
 
 #######################################################################################################################
 # ResizeHandle                                                                                                        #

--- a/volumina/skeletons/skeletonInterpreter.py
+++ b/volumina/skeletons/skeletonInterpreter.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 # 		   http://ilastik.org/license/
 ###############################################################################
 from builtins import range
-from PyQt5.QtCore import QObject, QEvent, Qt
+from qtpy.QtCore import QObject, QEvent, Qt
 import copy
 
 from volumina.eventswitch import InterpreterABC

--- a/volumina/skeletons/skeletonNode.py
+++ b/volumina/skeletons/skeletonNode.py
@@ -23,12 +23,12 @@ from __future__ import division
 ###############################################################################
 from builtins import range
 from past.utils import old_div
-from PyQt5.QtCore import QPointF, QObject, pyqtSignal
-from PyQt5.QtGui import QColor
+from qtpy.QtCore import QPointF, QObject, Signal
+from qtpy.QtGui import QColor
 
 
 class SkeletonNode(QObject):
-    selected = pyqtSignal(bool)
+    selected = Signal(bool)
 
     def __init__(self, pos3D, axis, skeletons):
         super(SkeletonNode, self).__init__()

--- a/volumina/skeletons/skeletons.py
+++ b/volumina/skeletons/skeletons.py
@@ -24,8 +24,8 @@ from __future__ import division
 # 		   http://ilastik.org/license/
 ###############################################################################
 from past.utils import old_div
-from PyQt5.QtCore import QPointF, QObject, pyqtSignal
-from PyQt5.QtWidgets import QGraphicsItem
+from qtpy.QtCore import QPointF, QObject, Signal
+from qtpy.QtWidgets import QGraphicsItem
 import numpy, copy
 
 from .skeletonNode import SkeletonNode
@@ -33,8 +33,8 @@ from .skeletonNode import SkeletonNode
 
 class Skeletons(QObject):
 
-    changed = pyqtSignal()
-    jumpRequested = pyqtSignal(object)
+    changed = Signal()
+    jumpRequested = Signal(object)
 
     SelectExclusive = 1
     SelectAdd = 2

--- a/volumina/skeletons/skeletonsLayer.py
+++ b/volumina/skeletons/skeletonsLayer.py
@@ -23,9 +23,9 @@ from __future__ import division
 ###############################################################################
 from builtins import range
 from past.utils import old_div
-from PyQt5.QtCore import QPointF, QRectF, QLineF, Qt
-from PyQt5.QtGui import QPen, QColor
-from PyQt5.QtWidgets import QGraphicsObject, QGraphicsRectItem, QGraphicsLineItem
+from qtpy.QtCore import QPointF, QRectF, QLineF, Qt
+from qtpy.QtGui import QPen, QColor
+from qtpy.QtWidgets import QGraphicsObject, QGraphicsRectItem, QGraphicsLineItem
 
 from volumina.skeletons.qGraphicsSkeletonNode import QGraphicsSkeletonNode
 

--- a/volumina/skeletons/skeletonsLayer3D.py
+++ b/volumina/skeletons/skeletonsLayer3D.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 # 		   http://ilastik.org/license/
 ###############################################################################
 from builtins import range
-from PyQt5.QtCore import QObject
+from qtpy.QtCore import QObject
 
 from volumina.skeletons.skeletonsLayer import SkeletonsLayer
 from volumina.skeletons.skeletonNode import SkeletonNode

--- a/volumina/sliceIntersectionMarker.py
+++ b/volumina/sliceIntersectionMarker.py
@@ -22,9 +22,9 @@ from __future__ import division
 # 		   http://ilastik.org/license/
 ###############################################################################
 from past.utils import old_div
-from PyQt5.QtCore import Qt, QRectF, QPointF
-from PyQt5.QtWidgets import QGraphicsItem, QApplication
-from PyQt5.QtGui import QPen, QCursor
+from qtpy.QtCore import Qt, QRectF, QPointF
+from qtpy.QtWidgets import QGraphicsItem, QApplication
+from qtpy.QtGui import QPen, QCursor
 
 # *******************************************************************************
 # S l i c e I n t e r s e c t i o n M a r k e r                                *

--- a/volumina/sliceSelectorHud.py
+++ b/volumina/sliceSelectorHud.py
@@ -25,9 +25,9 @@ from functools import partial
 
 import volumina
 from past.utils import old_div
-from PyQt5.QtCore import QCoreApplication, QEvent, QPointF, QSize, Qt, pyqtSignal
-from PyQt5.QtGui import QBrush, QColor, QFont, QIcon, QMouseEvent, QPainter, QPainterPath, QPen, QPixmap, QTransform
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import QCoreApplication, QEvent, QPointF, QSize, Qt, Signal
+from qtpy.QtGui import QBrush, QColor, QFont, QIcon, QMouseEvent, QPainter, QPainterPath, QPen, QPixmap, QTransform
+from qtpy.QtWidgets import (
     QAbstractSpinBox,
     QCheckBox,
     QFrame,
@@ -64,7 +64,7 @@ def _load_icon(filename, backgroundColor, width, height):
 # TODO: replace with QPushButton. in __init__(), read icon and give
 # correct background color.
 class LabelButtons(QLabel):
-    clicked = pyqtSignal()
+    clicked = Signal()
 
     def __init__(self, style, parentView, backgroundColor, foregroundColor, width, height):
         QLabel.__init__(self)
@@ -142,7 +142,7 @@ class LabelButtons(QLabel):
 
 
 class SpinBoxImageView(QHBoxLayout):
-    valueChanged = pyqtSignal(int)
+    valueChanged = Signal(int)
 
     def __init__(self, parentView, parent, backgroundColor, foregroundColor, value, height, fontSize):
         QHBoxLayout.__init__(self)
@@ -247,14 +247,14 @@ class ZoomLevelIndicator(QLabel):
 
 
 class ImageView2DHud(QWidget):
-    dockButtonClicked = pyqtSignal()
-    zoomToFitButtonClicked = pyqtSignal()
-    resetZoomButtonClicked = pyqtSignal()
-    maximizeButtonClicked = pyqtSignal()
-    rotLeftButtonClicked = pyqtSignal()
-    rotRightButtonClicked = pyqtSignal()
-    swapAxesButtonClicked = pyqtSignal()
-    exportButtonClicked = pyqtSignal()
+    dockButtonClicked = Signal()
+    zoomToFitButtonClicked = Signal()
+    resetZoomButtonClicked = Signal()
+    maximizeButtonClicked = Signal()
+    rotLeftButtonClicked = Signal()
+    rotRightButtonClicked = Signal()
+    swapAxesButtonClicked = Signal()
+    exportButtonClicked = Signal()
 
     def __init__(self, parent):
         QWidget.__init__(self, parent)
@@ -456,7 +456,7 @@ def _get_pos_widget(name, backgroundColor, foregroundColor):
 
 
 class QuadStatusBar(QHBoxLayout):
-    positionChanged = pyqtSignal(int, int, int)  # x,y,z
+    positionChanged = Signal(int, int, int)  # x,y,z
 
     def __init__(self, parent=None):
         QHBoxLayout.__init__(self, parent)
@@ -705,7 +705,7 @@ class QuadStatusBar(QHBoxLayout):
 
 if __name__ == "__main__":
     import sys
-    from PyQt5.QtWidgets import QDialog, QApplication
+    from qtpy.QtWidgets import QDialog, QApplication
 
     # make the program quit on Ctrl+C
     import signal

--- a/volumina/slicingtools.py
+++ b/volumina/slicingtools.py
@@ -33,7 +33,7 @@ not wrapped in a sequence.
 """
 from builtins import range
 import numpy as np
-from PyQt5.QtCore import QRect
+from qtpy.QtCore import QRect
 import itertools
 
 
@@ -62,7 +62,7 @@ def box(sl, seq=tuple):
 
     No effect on any other object.
 
-   """
+    """
     if isinstance(sl, slice):
         return seq((sl,))
     else:
@@ -82,7 +82,7 @@ def unbox(slicing, axis=0):
 
 
 def is_bounded(slicing):
-    """For all dimensions: stop value of slice is not None """
+    """For all dimensions: stop value of slice is not None"""
     slicing = box(slicing)
     return all((sl.stop != None for sl in slicing))
 

--- a/volumina/synchronizedEditors.py
+++ b/volumina/synchronizedEditors.py
@@ -19,8 +19,8 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from PyQt5.QtWidgets import QWidget, QGridLayout, QSizePolicy
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QWidget, QGridLayout, QSizePolicy
+from qtpy.QtCore import Qt
 from imageEditorComponents import PositionModelImage
 
 
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     # make the program quit on Ctrl+C
     import sys
     import signal
-    from PyQt5.QtWidgets import QApplication, QPushButton, QVBoxLayout
+    from qtpy.QtWidgets import QApplication, QPushButton, QVBoxLayout
     from imageEditorWidget import TestWidget
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)

--- a/volumina/thresholdingWidget_plugin.py
+++ b/volumina/thresholdingWidget_plugin.py
@@ -19,8 +19,8 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from PyQt5.QtDesigner import QPyDesignerCustomWidgetPlugin
-from PyQt5.QtWidgets import QPixmap, QIcon, QColor
+from qtpy.QtDesigner import QPyDesignerCustomWidgetPlugin
+from qtpy.QtWidgets import QPixmap, QIcon, QColor
 
 from volumina.widgets.thresholdingWidget import ThresholdingWidget
 

--- a/volumina/thresholdingcontroller.py
+++ b/volumina/thresholdingcontroller.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from past.utils import old_div
-from PyQt5.QtCore import Qt, QEvent, QObject, QPoint
+from qtpy.QtCore import Qt, QEvent, QObject, QPoint
 import numpy as np
 
 from volumina.eventswitch import InterpreterABC
@@ -39,8 +39,8 @@ class ThresholdingInterpreter(QObject, InterpreterABC):
         self._steps_delta = self._steps_mean * 2
         self._steps_scaling = 0.07
         self._range_max = (
-            4096.0
-        )  # hardcoded, in the case drange is not set in the data file or in the dataSelectionDialogue
+            4096.0  # hardcoded, in the case drange is not set in the data file or in the dataSelectionDialogue
+        )
         self._range_min = -4096.0
         self._range = np.abs(self._range_max - self._range_min)
         self._channel_range = dict()

--- a/volumina/tiling/cache.py
+++ b/volumina/tiling/cache.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Callable
 
 import numpy
-from PyQt5.QtWidgets import QGraphicsItem
+from qtpy.QtWidgets import QGraphicsItem
 
 from volumina.pixelpipeline.imagepump import StackedImageSources
 

--- a/volumina/tiling/tileprovider.py
+++ b/volumina/tiling/tileprovider.py
@@ -25,9 +25,9 @@ import time
 from contextlib import contextmanager
 from functools import partial
 
-from PyQt5.QtCore import QObject, QRect, QRectF, pyqtSignal
-from PyQt5.QtGui import QImage, QPainter, QTransform
-from PyQt5.QtWidgets import QGraphicsItem
+from qtpy.QtCore import QObject, QRect, QRectF, Signal
+from qtpy.QtGui import QImage, QPainter, QTransform
+from qtpy.QtWidgets import QGraphicsItem
 
 from volumina.pixelpipeline.imagepump import StackedImageSources
 from volumina.pixelpipeline.interface import IndeterminateRequestError
@@ -103,7 +103,7 @@ class TileProvider(QObject):
     )  # How 'complete' the composite tile is
     # (depending on how many layers are still dirty)
 
-    sceneRectChanged = pyqtSignal(QRectF)
+    sceneRectChanged = Signal(QRectF)
 
     @property
     def axesSwapped(self):

--- a/volumina/tiling/tiling.py
+++ b/volumina/tiling/tiling.py
@@ -21,8 +21,8 @@
 ###############################################################################
 import logging
 
-from PyQt5.QtCore import QRect, QRectF
-from PyQt5.QtGui import QTransform
+from qtpy.QtCore import QRect, QRectF
+from qtpy.QtGui import QTransform
 
 # volumina
 from volumina.patchAccessor import PatchAccessor

--- a/volumina/utility/getMainWindow.py
+++ b/volumina/utility/getMainWindow.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QApplication, QWidget, QMainWindow
+from qtpy.QtWidgets import QApplication, QWidget, QMainWindow
 
 
 def getMainWindow() -> QMainWindow:

--- a/volumina/utility/qabc.py
+++ b/volumina/utility/qabc.py
@@ -2,7 +2,7 @@
 Wraps stdlib abc module to provide convenience classes for defining QObject interfaces
 """
 
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod, _abc_init
 
 from qtpy.QtCore import QObject
 
@@ -21,8 +21,24 @@ class abstractsignal:
         pass
 
 
-class QABCMeta(type(QObject), ABCMeta):
-    pass
+class QABCMeta(ABCMeta, type(QObject)):
+    """
+    from: https://stackoverflow.com/a/78794968
+
+    tested with PyQt5, PySide6
+    """
+
+    def __new__(mcls, name, bases, ns, **kw):
+        cls = super().__new__(mcls, name, bases, ns, **kw)
+        _abc_init(cls)
+        return cls
+
+    def __call__(cls, *args, **kw):
+        if cls.__abstractmethods__:
+            raise TypeError(
+                f"Can't instantiate abstract class {cls.__name__} without an implementation for abstract methods {set(cls.__abstractmethods__)}"
+            )
+        return super().__call__(*args, **kw)
 
 
 class QABC(metaclass=QABCMeta):

--- a/volumina/utility/qabc.py
+++ b/volumina/utility/qabc.py
@@ -1,16 +1,17 @@
 """
 Wraps stdlib abc module to provide convenience classes for defining QObject interfaces
 """
+
 from abc import ABCMeta, abstractmethod
 
-from PyQt5.QtCore import QObject
+from qtpy.QtCore import QObject
 
 __all__ = ["QABC", "QABCMeta", "abstractmethod", "abstractsignal"]
 
 
 class abstractsignal:
     """
-    Should be used in place of pyqtSignal
+    Should be used in place of Signal
     NOTE: This class doesn't implement any typechecks as abc decorators also don't provide this capability
     """
 

--- a/volumina/utility/segmentationEdgesItem.py
+++ b/volumina/utility/segmentationEdgesItem.py
@@ -5,10 +5,10 @@ import logging
 
 import numpy as np
 
-from PyQt5.Qt import pyqtSignal
-from PyQt5.QtCore import Qt, QObject, QRectF, QPointF, QPoint
-from PyQt5.QtWidgets import QApplication, QGraphicsObject, QGraphicsPathItem, QGraphicsSceneHoverEvent
-from PyQt5.QtGui import QPainterPath, QPen, QColor, QPainterPathStroker, QPainter
+from qtpy.QtCore import Signal
+from qtpy.QtCore import Qt, QObject, QRectF, QPointF, QPoint
+from qtpy.QtWidgets import QApplication, QGraphicsObject, QGraphicsPathItem, QGraphicsSceneHoverEvent
+from qtpy.QtGui import QPainterPath, QPen, QColor, QPainterPathStroker, QPainter
 
 from volumina.utility import SignalingDict, edge_coords_nd, simplify_line_segments
 
@@ -20,8 +20,8 @@ class SegmentationEdgesItem(QGraphicsObject):
     A parent item for a collection of SingleEdgeItems.
     """
 
-    edgeClicked = pyqtSignal(tuple, object)  # id_pair, QGraphicsSceneMouseEvent
-    edgeSwiped = pyqtSignal(tuple, object)  # id_pair, QGraphicsSceneMouseEvent
+    edgeClicked = Signal(tuple, object)  # id_pair, QGraphicsSceneMouseEvent
+    edgeSwiped = Signal(tuple, object)  # id_pair, QGraphicsSceneMouseEvent
 
     def __init__(self, path_items, edge_pen_table, default_pen, *, hoverIdChanged=None, parent=None, isClickable=False):
         """
@@ -114,7 +114,6 @@ try:
             point_list = line_segments.reshape(-1, 2)
             painter_paths[edge_id] = arrayToQPath(point_list[:, 0], point_list[:, 1], connect="pairs")
         return painter_paths
-
 
 except ImportError:
     painter_paths_for_labels = painter_paths_for_labels_PURE_PYTHON
@@ -304,7 +303,7 @@ class defaultdict_with_key(defaultdict):
 ##
 ## Copied from PyQtGraph with slight modifications
 ##
-from PyQt5 import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore
 import struct
 
 
@@ -399,8 +398,8 @@ def arrayToQPath(x, y, connect="all"):
 if __name__ == "__main__":
     import time
     import numpy as np
-    from PyQt5.QtGui import QTransform
-    from PyQt5.QtWidgets import QApplication, QGraphicsView, QGraphicsScene
+    from qtpy.QtGui import QTransform
+    from qtpy.QtWidgets import QApplication, QGraphicsView, QGraphicsScene
 
     app = QApplication([])
 

--- a/volumina/utility/shortcutManager.py
+++ b/volumina/utility/shortcutManager.py
@@ -4,9 +4,9 @@ import logging
 from functools import partial
 from typing import Dict, Tuple
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QApplication, QShortcut
-from PyQt5.QtGui import QKeySequence
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QShortcut
+from qtpy.QtGui import QKeySequence
 from volumina.utility import Singleton, preferences, getMainWindow
 
 logger = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ class ShortcutManager(metaclass=Singleton):
         _d = _d or self._keyseq_target_actions
         reversemap = {}
         for keyseq, targets in list(_d.items()):
-            for (group, name) in targets:
+            for group, name in targets:
                 reversemap[(group, name)] = keyseq
         return reversemap
 
@@ -183,7 +183,7 @@ class ShortcutManager(metaclass=Singleton):
         self._global_shortcuts[keytext] = QShortcut(
             QKeySequence(keyseq),
             getMainWindow(),
-            member=partial(self._handle_shortcut_pressed, keytext),
+            partial(self._handle_shortcut_pressed, keytext),
             context=Qt.ApplicationShortcut,
         )
 
@@ -347,9 +347,9 @@ class ObjectWithToolTipABC(metaclass=abc.ABCMeta):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtCore import Qt, QEvent, QTimer
-    from PyQt5.QtWidgets import QApplication, QWidget, QLabel
-    from PyQt5.QtGui import QKeyEvent
+    from qtpy.QtCore import Qt, QEvent, QTimer
+    from qtpy.QtWidgets import QApplication, QWidget, QLabel
+    from qtpy.QtGui import QKeyEvent
 
     app = QApplication([])
 

--- a/volumina/utility/shortcutManagerDlg.py
+++ b/volumina/utility/shortcutManagerDlg.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import collections
 
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QDialog,
     QScrollArea,
     QHBoxLayout,
@@ -46,7 +46,7 @@ class ShortcutManagerDlg(QDialog):
         shortcutEdits = collections.OrderedDict()
         for group, targets in list(action_descriptions.items()):
             groupItem = QTreeWidgetItem(treeWidget, [group])
-            for (name, description) in targets:
+            for name, description in targets:
                 edit = QLineEdit(target_keyseqs[(group, name)])
                 shortcutEdits[(group, name)] = edit
                 item = QTreeWidgetItem(groupItem, [description])
@@ -93,11 +93,11 @@ class ShortcutManagerDlg(QDialog):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QShortcut
-    from PyQt5.QtGui import QKeySequence
+    from qtpy.QtWidgets import QShortcut
+    from qtpy.QtGui import QKeySequence
     from functools import partial
 
-    from PyQt5.QtWidgets import QApplication, QPushButton, QWidget
+    from qtpy.QtWidgets import QApplication, QPushButton, QWidget
 
     app = QApplication([])
 

--- a/volumina/utility/signalingDict.py
+++ b/volumina/utility/signalingDict.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
-from PyQt5.Qt import pyqtSignal
-from PyQt5.QtCore import QObject
+from qtpy.QtCore import Signal
+from qtpy.QtCore import QObject
 
 
 class SignalingDict(QObject):
@@ -18,7 +18,7 @@ class SignalingDict(QObject):
           - __missing__()
     """
 
-    updated = pyqtSignal(object)  # set(updated_keys)
+    updated = Signal(object)  # set(updated_keys)
 
     def __init__(self, parent):
         super(SignalingDict, self).__init__(parent)
@@ -115,7 +115,7 @@ class SignalingDict(QObject):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtCore import QCoreApplication
+    from qtpy.QtCore import QCoreApplication
 
     app = QCoreApplication([])
 

--- a/volumina/utility/thunkEvent.py
+++ b/volumina/utility/thunkEvent.py
@@ -23,8 +23,8 @@ from __future__ import print_function
 from future import standard_library
 
 standard_library.install_aliases()
-from PyQt5.QtCore import QObject, QEvent
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtCore import QObject, QEvent
+from qtpy.QtWidgets import QApplication
 from functools import partial
 
 
@@ -142,8 +142,8 @@ if __name__ == "__main__":
     from functools import partial
     from volumina.utility import execute_in_main_thread
 
-    from PyQt5.QtCore import QTimer
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtCore import QTimer
+    from qtpy.QtWidgets import QApplication
 
     app = QApplication([])
 

--- a/volumina/view3d/glview.py
+++ b/volumina/view3d/glview.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QVector4D
-from PyQt5.QtWidgets import QLabel
+from qtpy.QtCore import Signal
+from qtpy.QtGui import QVector4D
+from qtpy.QtWidgets import QLabel
 
 from volumina.utility import preferences
 import volumina.config
@@ -31,7 +31,7 @@ if volumina.config.CONFIG.show_3d_widget:
             slice_changed: emitted when the user dragged one of the slicing planes
         """
 
-        slice_changed = pyqtSignal()
+        slice_changed = Signal()
 
         def __init__(self, parent=None):
             GLViewWidget.__init__(self, parent)
@@ -205,7 +205,7 @@ if volumina.config.CONFIG.show_3d_widget:
 else:
 
     class GLViewMock(QLabel):
-        slice_changed = pyqtSignal()
+        slice_changed = Signal()
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)

--- a/volumina/view3d/meshgenerator.py
+++ b/volumina/view3d/meshgenerator.py
@@ -5,9 +5,9 @@ from numpy import where
 from pyqtgraph.opengl import MeshData, GLMeshItem
 from pyqtgraph.opengl.shaders import ShaderProgram, VertexShader, FragmentShader
 
-from PyQt5.QtCore import QThread, pyqtSignal
-from PyQt5.QtWidgets import QDialog
-from PyQt5.uic import loadUiType
+from qtpy.QtCore import QThread, Signal
+from qtpy.QtWidgets import QDialog
+from qtpy.uic import loadUiType
 
 
 try:
@@ -96,7 +96,7 @@ class MeshGenerator(QThread):
         mesh_generated: emitted when the generation finished, passes the label/name and generated mesh
     """
 
-    mesh_generated = pyqtSignal(object, object)
+    mesh_generated = Signal(object, object)
 
     def __init__(self, receiver, labeling, labels, name_mapping=None):
         """
@@ -137,7 +137,7 @@ class MeshGeneratorDialog(QDialog):
         finished: emitted when the export is finished. Passes the generated MeshData
     """
 
-    finished = pyqtSignal(object)
+    finished = Signal(object)
 
     def __init__(self, parent=None):
         super(MeshGeneratorDialog, self).__init__(parent)

--- a/volumina/view3d/overview3d.py
+++ b/volumina/view3d/overview3d.py
@@ -1,8 +1,8 @@
 from os.path import split, join
 
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtCore import pyqtSignal, pyqtSlot
-from PyQt5.uic import loadUiType
+from qtpy.QtWidgets import QWidget
+from qtpy.QtCore import Signal, Slot
+from qtpy.uic import loadUiType
 
 
 class Overview3D(QWidget):
@@ -28,9 +28,9 @@ class Overview3D(QWidget):
         dock_status_changed: indicates that the dock button was toggled
     """
 
-    slice_changed = pyqtSignal()
-    reinitialized = pyqtSignal()  # TODO: this should not be necessary: remove
-    dock_status_changed = pyqtSignal(bool)
+    slice_changed = Signal()
+    reinitialized = Signal()  # TODO: this should not be necessary: remove
+    dock_status_changed = Signal(bool)
 
     def __init__(self, is_3d_widget_visible=False, *args, **kwargs):
         """
@@ -38,7 +38,7 @@ class Overview3D(QWidget):
 
         :param is_3d_widget_visible: if True, the 3D widget will be visible
         """
-        super(QWidget, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         cls, _ = loadUiType(join(split(__file__)[0], "ui/view3d.ui"))
         self._ui = cls()
         self._ui.setupUi(self)
@@ -129,9 +129,9 @@ class Overview3D(QWidget):
         """
         return set(self._view.visible_meshes)
 
-    @pyqtSlot(bool, name="on_toggle_slice_x_clicked")
-    @pyqtSlot(bool, name="on_toggle_slice_y_clicked")
-    @pyqtSlot(bool, name="on_toggle_slice_z_clicked")
+    @Slot(bool, name="on_toggle_slice_x_clicked")
+    @Slot(bool, name="on_toggle_slice_y_clicked")
+    @Slot(bool, name="on_toggle_slice_z_clicked")
     def _on_toggle_slice(self, down):
         """
         The slot for the slice plane toggle button presses.
@@ -141,7 +141,7 @@ class Overview3D(QWidget):
         sender = self.sender()
         self._view.toggle_slice(str(sender.objectName()[-1]), down)
 
-    @pyqtSlot(bool, name="on_dock_clicked")
+    @Slot(bool, name="on_dock_clicked")
     def _on_dock_status_changed(self, status):
         """
         The slot for the dock status button.
@@ -160,7 +160,7 @@ class Overview3D(QWidget):
         """
         self._progress.setVisible(busy)
 
-    @pyqtSlot(int, name="on_show_3D_view_stateChanged")
+    @Slot(int, name="on_show_3D_view_stateChanged")
     def _on_toggle_3d_view(self, state):
         """
         Toggles the 3D widget.

--- a/volumina/view3d/ui/view3d.ui
+++ b/volumina/view3d/ui/view3d.ui
@@ -140,7 +140,7 @@
   <customwidget>
    <class>GLView</class>
    <extends>QGraphicsView</extends>
-   <header location="global">volumina.view3d.glview</header>
+   <header>volumina.view3d.glview</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/volumina/view3d/volumeRendering.py
+++ b/volumina/view3d/volumeRendering.py
@@ -19,7 +19,7 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 import numpy
 from colorsys import hsv_to_rgb
 from threading import current_thread
@@ -153,6 +153,8 @@ class RenderingManager(object):
     def invalidateObject(self, name):
         self._overview_scene.invalidate_object(name)
 
-    def clear(self,):
+    def clear(
+        self,
+    ):
         self._volume[:] = 0
         self.labelmgr.free()

--- a/volumina/viewer.py
+++ b/volumina/viewer.py
@@ -28,10 +28,10 @@ from volumina.layerstack import LayerStackModel
 from volumina.colortables import default16
 from volumina.volumeEditor import VolumeEditor
 
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QMainWindow, QApplication, QAction, qApp
-from PyQt5.uic import loadUi
+from qtpy.QtCore import QTimer, Signal
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QMainWindow, QApplication, QAction
+from qtpy.uic import loadUi
 
 import os
 import random
@@ -44,7 +44,7 @@ import random
 class ClickableSegmentationLayer(QObject):
 
     # whether label (int) is shown (true) or hidden (false)
-    clickedValue = pyqtSignal(int, bool, QColor)
+    clickedValue = Signal(int, bool, QColor)
 
     def __init__(self, seg, viewer, name=None, direct=None, parent=None, colortable=None, reuseColors=True):
         """
@@ -159,7 +159,7 @@ class Viewer(QMainWindow):
         self._viewerInitialized = False
         self.editor = None
         self.viewingWidget = None
-        self.actionQuit.triggered.connect(qApp.quit)
+        self.actionQuit.triggered.connect(QApplication.instance().quit)
 
         # when connecting in renderScreenshot to a partial(...) function,
         # we need to remember the created function to be able to disconnect
@@ -391,7 +391,7 @@ if __name__ == "__main__":
             segmentation_zyx.transpose(), "segmentation edges", default_pen=segmentation_pen
         )
 
-    # from PyQt5.QtWidgets import QGraphicsView
+    # from qtpy.QtWidgets import QGraphicsView
     # viewer.editor.imageViews[2].setOptimizationFlag(QGraphicsView.DontAdjustForAntialiasing, True)
 
     #     try:

--- a/volumina/volumeEditor.py
+++ b/volumina/volumeEditor.py
@@ -29,8 +29,17 @@ from functools import partial
 import numpy
 
 # PyQt
-from PyQt5.QtCore import pyqtSignal, QObject
-from PyQt5.QtWidgets import QApplication, QWidget, QUndoStack
+from qtpy.QtCore import Signal, QObject
+from qtpy.QtWidgets import QApplication
+
+import qtpy
+
+if qtpy.API_NAME in ("PyQt5", "PySide2"):
+    from qtpy.QtWidgets import QUndoStack
+elif qtpy.API_NAME in ("PyQt6", "PySide6"):
+    from qtpy.QtGui import QUndoStack
+else:
+    raise NotImplementedError(f"Invalid QT_API: '{qtpy.API_NAME}'")
 
 # volumina
 import volumina.pixelpipeline.imagepump
@@ -57,8 +66,8 @@ logger = logging.getLogger(__name__)
 
 
 class VolumeEditor(QObject):
-    newImageView2DFocus = pyqtSignal()
-    shapeChanged = pyqtSignal()
+    newImageView2DFocus = Signal()
+    shapeChanged = Signal()
 
     @property
     def showDebugPatches(self):

--- a/volumina/volumeEditorWidget.py
+++ b/volumina/volumeEditorWidget.py
@@ -32,9 +32,9 @@ import copy
 import numpy
 
 # PyQt
-from PyQt5.QtCore import Qt, QRectF, QEvent, QObject, QTimerEvent, QTimer
-from PyQt5.QtGui import QKeySequence, QColor, QIcon
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import Qt, QRectF, QEvent, QObject, QTimerEvent, QTimer
+from qtpy.QtGui import QKeySequence, QColor, QIcon
+from qtpy.QtWidgets import (
     QApplication,
     QWidget,
     QShortcut,

--- a/volumina/volumeEditorWidget_plugin.py
+++ b/volumina/volumeEditorWidget_plugin.py
@@ -19,8 +19,8 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from PyQt5.QtDesigner import QPyDesignerCustomWidgetPlugin
-from PyQt5.QtWidgets import QPixmap, QIcon
+from qtpy.QtDesigner import QPyDesignerCustomWidgetPlugin
+from qtpy.QtWidgets import QPixmap, QIcon
 
 import numpy
 

--- a/volumina/widgets/dataExportOptionsDlg.py
+++ b/volumina/widgets/dataExportOptionsDlg.py
@@ -25,10 +25,10 @@ from functools import partial
 
 import numpy
 
-from PyQt5 import uic
-from PyQt5.QtCore import Qt, QObject, QEvent
-from PyQt5.QtWidgets import QDialog, QDialogButtonBox
-from PyQt5.QtGui import QValidator
+from qtpy import uic
+from qtpy.QtCore import Qt, QObject, QEvent
+from qtpy.QtWidgets import QDialog, QDialogButtonBox
+from qtpy.QtGui import QValidator
 
 try:
     from lazyflow.graph import Operator, InputSlot, OutputSlot
@@ -497,7 +497,7 @@ def dtype_limits(dtype):
 # **************************************************************************
 if __name__ == "__main__":
     import vigra
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     from lazyflow.graph import Graph
     from lazyflow.operators.ioOperators import OpFormattedDataExport
 

--- a/volumina/widgets/delayedSpinBox.py
+++ b/volumina/widgets/delayedSpinBox.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
-from PyQt5.QtCore import pyqtSignal, QTimer
-from PyQt5.QtWidgets import QSpinBox
+from qtpy.QtCore import Signal, QTimer
+from qtpy.QtWidgets import QSpinBox
 
 
 class DelayedSpinBox(QSpinBox):
@@ -9,7 +9,7 @@ class DelayedSpinBox(QSpinBox):
     which waits for a bit before signaling with the user's new input.
     """
 
-    delayedValueChanged = pyqtSignal(int)
+    delayedValueChanged = Signal(int)
 
     def __init__(self, delay_ms, *args, **kwargs):
         super(DelayedSpinBox, self).__init__(*args, **kwargs)
@@ -49,7 +49,7 @@ class DelayedSpinBox(QSpinBox):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication, QWidget, QLabel, QVBoxLayout
+    from qtpy.QtWidgets import QApplication, QWidget, QLabel, QVBoxLayout
 
     app = QApplication([])
 

--- a/volumina/widgets/dvidVolumeExportOptionsWidget.py
+++ b/volumina/widgets/dvidVolumeExportOptionsWidget.py
@@ -24,7 +24,7 @@ from __future__ import print_function
 import os
 import sys
 
-from PyQt5.QtWidgets import QWidget, QLabel, QPushButton, QHBoxLayout, QVBoxLayout
+from qtpy.QtWidgets import QWidget, QLabel, QPushButton, QHBoxLayout, QVBoxLayout
 from libdvid.gui.contents_browser import ContentsBrowser
 from lazyflow.utility import isUrl
 
@@ -82,7 +82,7 @@ class DvidVolumeExportOptionsWidget(QWidget):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     from lazyflow.graph import Graph
 
     from lazyflow.operators.ioOperators import OpExportDvidVolume

--- a/volumina/widgets/exportHelper.py
+++ b/volumina/widgets/exportHelper.py
@@ -25,8 +25,8 @@ from functools import partial
 import typing
 
 # Qt
-from PyQt5.QtCore import pyqtSignal, QObject
-from PyQt5.QtWidgets import QMessageBox
+from qtpy.QtCore import Signal, QObject
+from qtpy.QtWidgets import QMessageBox
 
 # volumina
 from .dataExportOptionsDlg import DataExportOptionsDlg
@@ -85,9 +85,7 @@ def _get_stacked_data_sources(layer: Layer) -> OpMultiArrayStacker:
     opStackChannels = lazyflow.operators.OpMultiArrayStacker(dataSlots[0].operator.parent)
     for slot in dataSlots:
         assert isinstance(slot, lazyflow.graph.Slot), f"slot is of type {type(slot)!r}"
-        assert isinstance(
-            slot.operator, lazyflow.graph.Operator
-        ), f"slot's operator is of type {type(slot.operator)!r}"
+        assert isinstance(slot.operator, lazyflow.graph.Operator), f"slot's operator is of type {type(slot.operator)!r}"
     opStackChannels.AxisFlag.setValue("c")
     opStackChannels.Images.resize(len(dataSlots))
     for i, islot in enumerate(opStackChannels.Images):
@@ -148,7 +146,7 @@ class ExportHelper(QObject):
 
     # This signal is used to ensure that request
     #  callbacks are executed in the gui thread
-    _forwardingSignal = pyqtSignal(object)
+    _forwardingSignal = Signal(object)
 
     def _handleForwardedCall(self, fn):
         # Execute the callback

--- a/volumina/widgets/hierarchicalFileExportOptionsWidget.py
+++ b/volumina/widgets/hierarchicalFileExportOptionsWidget.py
@@ -22,13 +22,13 @@
 import os
 from typing import Tuple
 
-from PyQt5 import uic
-from PyQt5.QtCore import pyqtSignal, Qt, QEvent
-from PyQt5.QtWidgets import QWidget, QFileDialog, QLabel
+from qtpy import uic
+from qtpy.QtCore import Signal, Qt, QEvent
+from qtpy.QtWidgets import QWidget, QFileDialog, QLabel
 
 
 class HierarchicalFileExportOptionsWidget(QWidget):
-    pathValidityChange = pyqtSignal(bool)
+    pathValidityChange = Signal(bool)
 
     def __init__(self, parent, file_extensions: Tuple[str, ...], extension_description: str):
         super().__init__(parent)
@@ -138,7 +138,7 @@ class HierarchicalFileExportOptionsWidget(QWidget):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     from lazyflow.graph import Graph, Operator, InputSlot
 
     class OpMock(Operator):

--- a/volumina/widgets/layerDialog.py
+++ b/volumina/widgets/layerDialog.py
@@ -25,9 +25,9 @@ from __future__ import print_function
 import os
 
 # PyQt
-from PyQt5 import uic
-from PyQt5.QtWidgets import QDialog
-from PyQt5.QtCore import Qt
+from qtpy import uic
+from qtpy.QtWidgets import QDialog
+from qtpy.QtCore import Qt
 from functools import partial
 from typing import Callable
 from pathlib import Path
@@ -106,7 +106,7 @@ class RGBALayerDialog(LayerDialog):
 if __name__ == "__main__":
     import optparse
     import sys
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
 
     parser = optparse.OptionParser()
     parser.add_option("--gray", action="store_true")

--- a/volumina/widgets/layercontextmenu.py
+++ b/volumina/widgets/layercontextmenu.py
@@ -26,9 +26,9 @@ from builtins import range
 from functools import partial
 
 # Qt
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QMenu, QAction, QDialog, QHBoxLayout, QTableWidget, QSizePolicy, QTableWidgetItem
-from PyQt5.QtGui import QColor
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QMenu, QAction, QDialog, QHBoxLayout, QTableWidget, QSizePolicy, QTableWidgetItem
+from qtpy.QtGui import QColor
 
 # volumina
 from volumina.layer import ColortableLayer, GrayscaleLayer, RGBALayer, ClickableColortableLayer, SegmentationEdgesLayer

--- a/volumina/widgets/layerwidget.py
+++ b/volumina/widgets/layerwidget.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-
 ###############################################################################
 #   volumina: volume slicing and editing library
 #
@@ -25,15 +22,15 @@ from __future__ import division
 from builtins import range
 from past.utils import old_div
 import warnings
-from PyQt5.QtCore import pyqtSignal, Qt, QEvent, QRect, QSize, QTimer, QPoint, QItemSelectionModel
-from PyQt5.QtGui import QPainter, QFontMetrics, QFont, QPalette, QMouseEvent, QPixmap
-from PyQt5.QtWidgets import QStyledItemDelegate, QWidget, QListView, QStyle, QLabel, QGridLayout, QSpinBox, QApplication
+from qtpy.QtCore import Signal, Qt, QEvent, QRect, QSize, QTimer, QPoint, QItemSelectionModel
+from qtpy.QtGui import QPainter, QFontMetrics, QFont, QPalette, QMouseEvent, QPixmap
+from qtpy.QtWidgets import QStyledItemDelegate, QWidget, QListView, QStyle, QLabel, QGridLayout, QSpinBox, QApplication
 
 
 from volumina.layer import Layer
 from volumina.layerstack import LayerStackModel
 from volumina.utility import ShortcutManager
-from .layercontextmenu import layercontextmenu
+from volumina.widgets.layercontextmenu import layercontextmenu
 
 
 NEXT_CHANNEL_SEQ = "Ctrl+N"
@@ -41,7 +38,7 @@ PREV_CHANNEL_SEQ = "Ctrl+P"
 
 
 class FractionSelectionBar(QWidget):
-    fractionChanged = pyqtSignal(float)
+    fractionChanged = Signal(float)
 
     def __init__(self, initial_fraction=1.0, parent=None):
         super(FractionSelectionBar, self).__init__(parent=parent)
@@ -128,7 +125,7 @@ class FractionSelectionBar(QWidget):
 
 
 class ToggleEye(QLabel):
-    activeChanged = pyqtSignal(bool)
+    activeChanged = Signal(bool)
 
     def __init__(self, parent=None):
         super(ToggleEye, self).__init__(parent=parent)
@@ -482,7 +479,7 @@ if __name__ == "__main__":
 
     import sys, numpy
 
-    from PyQt5.QtWidgets import QPushButton, QHBoxLayout, QVBoxLayout
+    from qtpy.QtWidgets import QPushButton, QHBoxLayout, QVBoxLayout
     from volumina.pixelpipeline.datasources import ArraySource, ConstantSource
 
     app = QApplication(sys.argv)

--- a/volumina/widgets/multiStepProgressDialog.py
+++ b/volumina/widgets/multiStepProgressDialog.py
@@ -24,8 +24,8 @@ from __future__ import division
 from past.utils import old_div
 import os, time
 
-from PyQt5 import uic
-from PyQt5.QtWidgets import QDialog, QDialogButtonBox
+from qtpy import uic
+from qtpy.QtWidgets import QDialog, QDialogButtonBox
 
 
 class MultiStepProgressDialog(QDialog):
@@ -101,7 +101,7 @@ class MultiStepProgressDialog(QDialog):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     import vigra, numpy
 
     app = QApplication(list())

--- a/volumina/widgets/multiformatSlotExportFileOptionsWidget.py
+++ b/volumina/widgets/multiformatSlotExportFileOptionsWidget.py
@@ -23,9 +23,9 @@ import collections
 import os
 import re
 
-from PyQt5 import uic
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QWidget
+from qtpy import uic
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QWidget
 
 from .hierarchicalFileExportOptionsWidget import HierarchicalFileExportOptionsWidget
 from .multiscaleFileExportOptionsWidget import MultiscaleFileExportOptionsWidget
@@ -48,8 +48,8 @@ except ImportError:
 
 
 class MultiformatSlotExportFileOptionsWidget(QWidget):
-    formatValidityChange = pyqtSignal(str)  # str
-    pathValidityChange = pyqtSignal(bool)
+    formatValidityChange = Signal(str)  # str
+    pathValidityChange = Signal(bool)
 
     def __init__(self, parent):
         global _has_lazyflow
@@ -215,7 +215,7 @@ class MultiformatSlotExportFileOptionsWidget(QWidget):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     from lazyflow.graph import Graph, Operator, InputSlot
     from lazyflow.operators.ioOperators import OpFormattedDataExport
 

--- a/volumina/widgets/multiscaleFileExportOptionsWidget.py
+++ b/volumina/widgets/multiscaleFileExportOptionsWidget.py
@@ -21,9 +21,9 @@
 ###############################################################################
 import os
 
-from PyQt5 import uic
-from PyQt5.QtCore import pyqtSignal, Qt, QEvent
-from PyQt5.QtWidgets import QWidget, QFileDialog
+from qtpy import uic
+from qtpy.QtCore import Signal, Qt, QEvent
+from qtpy.QtWidgets import QWidget, QFileDialog
 
 
 class MultiscaleFileExportOptionsWidget(QWidget):

--- a/volumina/widgets/singleFileExportOptionsWidget.py
+++ b/volumina/widgets/singleFileExportOptionsWidget.py
@@ -24,9 +24,9 @@ from __future__ import print_function
 import os
 import sys
 
-from PyQt5 import uic
-from PyQt5.QtCore import Qt, QEvent
-from PyQt5.QtWidgets import QWidget, QFileDialog
+from qtpy import uic
+from qtpy.QtCore import Qt, QEvent
+from qtpy.QtWidgets import QWidget, QFileDialog
 
 
 class SingleFileExportOptionsWidget(QWidget):
@@ -85,7 +85,7 @@ class SingleFileExportOptionsWidget(QWidget):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     from lazyflow.graph import Graph
     from lazyflow.operators.ioOperators import OpNpyWriter
 

--- a/volumina/widgets/slotMetaInfoDisplayWidget.py
+++ b/volumina/widgets/slotMetaInfoDisplayWidget.py
@@ -21,9 +21,9 @@
 ###############################################################################
 import os
 
-import sip
-from PyQt5 import uic
-from PyQt5.QtWidgets import QWidget
+import qtpy.compat
+from qtpy import uic
+from qtpy.QtWidgets import QWidget
 
 
 class SlotMetaDisplayData:
@@ -60,7 +60,7 @@ class SlotMetaInfoDisplayWidget(QWidget):
 
     def update_labels(self, *args):
         labels = self._get_labels() if self._slot.ready() else SlotMetaDisplayData()
-        if not sip.isdeleted(self.shapeDisplay):
+        if qtpy.compat.isalive(self.shapeDisplay):
             self.shapeDisplay.setText(labels.shape)
             self.axisOrderDisplay.setText(labels.axes)
             self.dtypeDisplay.setText(labels.dtype)

--- a/volumina/widgets/stackExportFileOptionsWidget.py
+++ b/volumina/widgets/stackExportFileOptionsWidget.py
@@ -23,9 +23,9 @@ import os
 import sys
 import re
 
-from PyQt5 import uic
-from PyQt5.QtCore import pyqtSignal, Qt, QEvent
-from PyQt5.QtWidgets import QWidget, QFileDialog
+from qtpy import uic
+from qtpy.QtCore import Signal, Qt, QEvent
+from qtpy.QtWidgets import QWidget, QFileDialog
 
 try:
     from lazyflow.operators.ioOperators import OpStackWriter
@@ -36,7 +36,7 @@ except:
 
 
 class StackExportFileOptionsWidget(QWidget):
-    pathValidityChange = pyqtSignal(bool)
+    pathValidityChange = Signal(bool)
 
     def __init__(self, parent, extension):
         global _has_lazyflow
@@ -133,7 +133,7 @@ class StackExportFileOptionsWidget(QWidget):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     from lazyflow.graph import Graph
     from lazyflow.operators.ioOperators import OpFormattedDataExport
 

--- a/volumina/widgets/subregionRoiWidget.py
+++ b/volumina/widgets/subregionRoiWidget.py
@@ -20,8 +20,8 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 import collections
-from PyQt5.QtCore import Qt, pyqtSignal, QEvent
-from PyQt5.QtWidgets import QSpinBox, QTableWidget, QTableWidgetItem
+from qtpy.QtCore import Qt, Signal, QEvent
+from qtpy.QtWidgets import QSpinBox, QTableWidget, QTableWidgetItem
 
 DEFAULT_MAX_EXTENT = 999999
 
@@ -79,7 +79,7 @@ class SubregionRoiWidget(QTableWidget):
     """
 
     #: emit(tuple, tuple), tuples may contain 'None' to indicate 'full range'
-    roiChanged = pyqtSignal(object, object)
+    roiChanged = Signal(object, object)
 
     def __init__(self, parent):
         super(SubregionRoiWidget, self).__init__(parent)
@@ -201,7 +201,7 @@ class SubregionRoiWidget(QTableWidget):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
 
     app = QApplication([])
 

--- a/volumina/widgets/thresholdingWidget.py
+++ b/volumina/widgets/thresholdingWidget.py
@@ -23,15 +23,15 @@ from os import path
 from typing import Tuple
 from numbers import Number
 
-from PyQt5 import uic
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QWidget, QButtonGroup
+from qtpy import uic
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QWidget, QButtonGroup
 
 # ===----------------------------------------------------------------------------------------------------------------===
 
 
 class ThresholdingWidget(QWidget):
-    valueChanged = pyqtSignal(int, int)
+    valueChanged = Signal(int, int)
 
     def __init__(self, parent=None):
         QWidget.__init__(self, parent)
@@ -92,7 +92,7 @@ class ThresholdingWidget(QWidget):
 # ===----------------------------------------------------------------------------------------------------------------===
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
 
     app = QApplication([])
     w = ThresholdingWidget()

--- a/volumina/widgets/valueRangeWidget.py
+++ b/volumina/widgets/valueRangeWidget.py
@@ -22,7 +22,7 @@
 import os
 from functools import partial
 
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QWidget,
     QDoubleSpinBox,
     QHBoxLayout,
@@ -32,13 +32,13 @@ from PyQt5.QtWidgets import (
     QSpacerItem,
     QSizePolicy,
 )
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5 import uic
+from qtpy.QtCore import Qt, Signal
+from qtpy import uic
 import numpy
 
 
 class ValueRangeWidget(QWidget):
-    changedSignal = pyqtSignal()
+    changedSignal = Signal()
 
     def __init__(self, parent=None, dtype=numpy.float32):
         super(ValueRangeWidget, self).__init__(parent)
@@ -197,7 +197,7 @@ class CombinedValueRangeWidget(QWidget):
 
 
 if __name__ == "__main__":
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     import numpy
 
     app = QApplication(list())

--- a/volumina/widgets/wysiwygExportOptionsDlg.py
+++ b/volumina/widgets/wysiwygExportOptionsDlg.py
@@ -25,10 +25,10 @@ from itertools import product
 from operator import mul, itemgetter
 import os
 
-from PyQt5 import uic
-from PyQt5.QtCore import Qt, QEvent, QRectF
-from PyQt5.QtGui import QImageWriter, QImage, QPainter, qRgb
-from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QFileDialog, QColorDialog, QApplication
+from qtpy import uic
+from qtpy.QtCore import Qt, QEvent, QRectF
+from qtpy.QtGui import QImageWriter, QImage, QPainter, qRgb
+from qtpy.QtWidgets import QDialog, QDialogButtonBox, QFileDialog, QColorDialog, QApplication
 from functools import reduce
 
 try:


### PR DESCRIPTION
In order to prepare enabling/switching to Pyside6 (qt6!) I propose to go via qtpy. This enables us to switch qt apis more flexibly. I already tested volumina with Pyside6. With this PR, this does not require any code changes. Note that the qt bindings with this pr are still PyQt5.