### PR TITLE
dependecy upgrade aftermath

### DIFF
--- a/volumina/layer.py
+++ b/volumina/layer.py
@@ -38,7 +38,7 @@ from functools import partial
 from collections import defaultdict
 
 import sys
-from numbers import Number
+from numbers import Real
 from typing import Tuple
 
 
@@ -301,10 +301,10 @@ class NormalizableLayer(Layer):
         self._normalize[datasourceIdx] = value
         self.normalizeChanged.emit()
 
-    def get_datasource_default_range(self, datasourceIdx: int) -> Tuple[Number, Number]:
+    def get_datasource_default_range(self, datasourceIdx: int) -> Tuple[Real, Real]:
         return self._datasources[datasourceIdx]._bounds
 
-    def get_datasource_range(self, datasourceIdx: int) -> Tuple[Number, Number]:
+    def get_datasource_range(self, datasourceIdx: int) -> Tuple[Real, Real]:
         if isinstance(self._normalize[datasourceIdx], tuple):
             return self._normalize[datasourceIdx]
         return self.get_datasource_default_range(datasourceIdx)

--- a/volumina/widgets/layerDialog.py
+++ b/volumina/widgets/layerDialog.py
@@ -32,6 +32,7 @@ from functools import partial
 from typing import Callable
 from pathlib import Path
 
+from volumina.layer import NormalizableLayer
 from volumina.widgets.thresholdingWidget import ThresholdingWidget
 
 import logging
@@ -40,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 
 class LayerDialog(QDialog):
-    def __init__(self, ui_file_name: str, layer, parent=None):
+    def __init__(self, ui_file_name: str, layer: NormalizableLayer, parent=None):
         super().__init__(parent)
         base_path = Path(__file__).resolve().parent
         ui_path = base_path.joinpath("ui").joinpath(ui_file_name)
@@ -56,7 +57,7 @@ class LayerDialog(QDialog):
         thresholding_widget.setRange(normalization_range[0], normalization_range[1])
 
         normalization_value = self.layer.get_datasource_range(datasourceIdx)
-        thresholding_widget.setValue(normalization_value[0], normalization_value[1])
+        thresholding_widget.setValue(int(normalization_value[0]), int(normalization_value[1]))
 
         thresholding_widget.valueChanged.connect(handleRangeChanged)
 

--- a/volumina/widgets/thresholdingWidget.py
+++ b/volumina/widgets/thresholdingWidget.py
@@ -21,17 +21,22 @@
 ###############################################################################
 from os import path
 from typing import Tuple
-from numbers import Number
 
 from qtpy import uic
 from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QWidget, QButtonGroup
+from qtpy.QtWidgets import QLabel, QSlider, QSpinBox, QWidget
 
 # ===----------------------------------------------------------------------------------------------------------------===
 
 
 class ThresholdingWidget(QWidget):
     valueChanged = Signal(int, int)
+
+    _minSlider: QSlider
+    _maxSlider: QSlider
+    _minSpin: QSpinBox
+    _maxSpin: QSpinBox
+    _layerLabel: QLabel
 
     def __init__(self, parent=None):
         QWidget.__init__(self, parent)
@@ -77,13 +82,13 @@ class ThresholdingWidget(QWidget):
         self._minSpin.setValue(minimum)
         self._maxSpin.setValue(maximum)
 
-    def setValue(self, minimum, maximum):
+    def setValue(self, minimum: int, maximum: int):
         self._minSlider.setValue(minimum)
         self._maxSlider.setValue(maximum)
         self._minSpin.setValue(minimum)
         self._maxSpin.setValue(maximum)
 
-    def getRange(self) -> Tuple[Number, Number]:
+    def getRange(self) -> Tuple[int, int]:
         return (self._minSpin.value(), self._maxSpin.value())
 
 


### PR DESCRIPTION
We're simultaneously switched, updated some dependencies (qtpy, pyqt5), this comes with some friction (usually tighter type requirements)

* `QSlider`, `QSpinBox` need ints when setting ranges.