### PR TITLE
Fix Screenshot functionality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test-w-ilastik-env:
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
@@ -54,6 +55,7 @@ jobs:
 
   test-w-conda-recipe:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         python_version: ["3.10", "3.11", "3.12", "3.13"]

--- a/tests/crossHairCursor_test.py
+++ b/tests/crossHairCursor_test.py
@@ -1,0 +1,109 @@
+###############################################################################
+#   volumina: volume slicing and editing library
+#
+#       Copyright (C) 2011-2026, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#          http://ilastik.org/license/
+###############################################################################
+import pytest
+from qtpy.QtCore import QRectF, Qt
+from qtpy.QtGui import QColor, QTransform
+from qtpy.QtWidgets import QGraphicsScene, QGraphicsView
+
+from volumina.crossHairCursor import CrossHairCursor
+
+
+class MockImageScene(QGraphicsScene):
+    def __init__(self):
+        super().__init__()
+        self.data2scene = QTransform()
+
+
+def test_bounding_rect(qtbot):
+    cursor = CrossHairCursor()
+    scene = MockImageScene()
+    scene.addItem(cursor)
+    view = QGraphicsView()
+    view.setScene(scene)
+    qtbot.addWidget(view)
+
+    cursor.dataShape = (42, 60)
+
+    rect = cursor.boundingRect()
+
+    assert isinstance(rect, QRectF)
+    assert rect.width() == 42
+    assert rect.height() == 60
+
+
+def test_data_shape():
+    cursor = CrossHairCursor()
+
+    cursor.dataShape = (42, 1024)
+
+    assert cursor.dataShape == (42, 1024)
+    assert cursor._width == 42
+    assert cursor._height == 1024
+
+
+@pytest.mark.parametrize("position", [(0, 0), (1, 1), (4, 2), (1000, 50000), (-10, 20)])
+def test_show_xy_position(position: tuple[int, int]):
+    cursor = CrossHairCursor()
+
+    cursor.showXYPosition(*position)
+    assert cursor.x == position[0]
+    assert cursor.y == position[1]
+
+
+@pytest.mark.parametrize("brush_size", [1, 4, 13, 42, 100])
+def test_set_brush_size(brush_size: int):
+    cursor = CrossHairCursor()
+
+    cursor.setBrushSize(brush_size)
+
+    assert cursor.brushSize == brush_size
+
+
+@pytest.mark.parametrize("color", [Qt.green, Qt.red, QColor.fromRgba(0xEEAACCDD)])
+def test_set_color(color: QColor):
+    cursor = CrossHairCursor()
+
+    cursor.setColor(color)
+
+    assert cursor.penSolid.color() == color
+    assert cursor.penDotted.color() == color
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_enabled(enabled: bool):
+    cursor = CrossHairCursor()
+
+    cursor.enabled = enabled
+
+    assert cursor.enabled is enabled
+
+
+@pytest.mark.parametrize("state_before", [True, False])
+def test_hidden_context_restores_state(state_before: bool):
+    cursor = CrossHairCursor()
+
+    cursor.setVisible(state_before)
+
+    with cursor.hidden():
+        assert not cursor.isVisible()
+
+    assert cursor.isVisible() == state_before

--- a/volumina/crossHairCursor.py
+++ b/volumina/crossHairCursor.py
@@ -66,10 +66,6 @@ class CrossHairCursor(QGraphicsItem):
     and marks the size of the current brush.
     """
 
-    modeYPosition = 0
-    modeXPosition = 1
-    modeXYPosition = 2
-
     def boundingRect(self):
         return self.scene().data2scene.mapRect(QRectF(0, 0, self._width, self._height))
 
@@ -89,7 +85,6 @@ class CrossHairCursor(QGraphicsItem):
         self.y = 0
         self.brushSize = 0
 
-        self.mode = self.modeXYPosition
         self._enabled = True
 
     @property
@@ -127,23 +122,10 @@ class CrossHairCursor(QGraphicsItem):
         self.penSolid.setCosmetic(True)
         self.update()
 
-    def showXPosition(self, x, y):
-        """only mark the x position by displaying a line f(y) = x"""
-        self.setVisible(True)
-        self.mode = self.modeXPosition
-        self.setPos(x, y - int(y))
-
-    def showYPosition(self, y, x):
-        """only mark the y position by displaying a line f(x) = y"""
-        self.setVisible(True)
-        self.mode = self.modeYPosition
-        self.setPos(x - int(x), y)
-
     def showXYPosition(self, x, y):
         """mark the (x,y) position by displaying a cross hair cursor
         including a circle indicating the current brush size"""
         self.setVisible(True)
-        self.mode = self.modeXYPosition
         self.setPos(x, y)
 
     def paint(self, painter, option, widget=None):
@@ -153,27 +135,22 @@ class CrossHairCursor(QGraphicsItem):
 
         painter.setPen(self.penDotted)
 
-        if self.mode == self.modeXPosition:
-            painter.drawLine(QPointF(self.x + 0.5, 0), QPointF(self.x + 0.5, self._height))
-        elif self.mode == self.modeYPosition:
-            painter.drawLine(QPointF(0, self.y), QPointF(self.width, self.y))
-        else:
-            painter.drawLine(
-                QPointF(self.x - 0.5 * self.brushSize - 3, self.y), QPointF(self.x - 0.5 * self.brushSize, self.y)
-            )
-            painter.drawLine(
-                QPointF(self.x + 0.5 * self.brushSize, self.y), QPointF(self.x + 0.5 * self.brushSize + 3, self.y)
-            )
+        painter.drawLine(
+            QPointF(self.x - 0.5 * self.brushSize - 3, self.y), QPointF(self.x - 0.5 * self.brushSize, self.y)
+        )
+        painter.drawLine(
+            QPointF(self.x + 0.5 * self.brushSize, self.y), QPointF(self.x + 0.5 * self.brushSize + 3, self.y)
+        )
 
-            painter.drawLine(
-                QPointF(self.x, self.y - 0.5 * self.brushSize - 3), QPointF(self.x, self.y - 0.5 * self.brushSize)
-            )
-            painter.drawLine(
-                QPointF(self.x, self.y + 0.5 * self.brushSize), QPointF(self.x, self.y + 0.5 * self.brushSize + 3)
-            )
+        painter.drawLine(
+            QPointF(self.x, self.y - 0.5 * self.brushSize - 3), QPointF(self.x, self.y - 0.5 * self.brushSize)
+        )
+        painter.drawLine(
+            QPointF(self.x, self.y + 0.5 * self.brushSize), QPointF(self.x, self.y + 0.5 * self.brushSize + 3)
+        )
 
-            painter.setPen(self.penSolid)
-            painter.drawEllipse(QPointF(self.x, self.y), 0.5 * self.brushSize, 0.5 * self.brushSize)
+        painter.setPen(self.penSolid)
+        painter.drawEllipse(QPointF(self.x, self.y), 0.5 * self.brushSize, 0.5 * self.brushSize)
 
         painter.restore()
 

--- a/volumina/crossHairCursor.py
+++ b/volumina/crossHairCursor.py
@@ -48,6 +48,8 @@
 #    authors and should not be interpreted as representing official policies, either expressed
 #    or implied, of their employers.
 
+from contextlib import contextmanager
+from typing import Iterator
 from qtpy.QtCore import Qt, QPointF, QRectF
 from qtpy.QtGui import QPen
 from qtpy.QtWidgets import QGraphicsItem
@@ -183,3 +185,12 @@ class CrossHairCursor(QGraphicsItem):
     def setBrushSize(self, size):
         self.brushSize = size
         self.update()
+
+    @contextmanager
+    def hidden(self) -> Iterator["CrossHairCursor"]:
+        visible = self.isVisible()
+        self.setVisible(False)
+        try:
+            yield self
+        finally:
+            self.setVisible(visible)

--- a/volumina/imageScene2D.py
+++ b/volumina/imageScene2D.py
@@ -68,7 +68,7 @@ class DirtyIndicator(QGraphicsItem):
         self._zeroProgressTimestamp = [datetime.datetime.now()] * len(tiling)
         self._last_zero = False
 
-    def boundingRect(self):
+    def boundingRect(self) -> QRectF:
         return self._tiling.boundingRectF()
 
     def paint(self, painter, option, widget):

--- a/volumina/imageView2D.py
+++ b/volumina/imageView2D.py
@@ -126,7 +126,6 @@ class ImageView2D(QGraphicsView):
         self._slices = None  # number of slices that are stacked
         self._hud = None
 
-        self._crossHairCursor = None
         self._sliceIntersectionMarker = None
 
         self._ticker = QTimer(self)
@@ -303,7 +302,8 @@ class ImageView2D(QGraphicsView):
 
             exportHelper = WysiwygExportHelper(self, settingsDlg)
             exportHelper.prepareExport()
-            exportHelper.run()
+            with self._crossHairCursor.hidden():
+                exportHelper.run()
         else:
             # user didn't click OK button -> do nothing
             return

--- a/volumina/tiling/tiling.py
+++ b/volumina/tiling/tiling.py
@@ -121,7 +121,7 @@ class Tiling(object):
             self.imageRects[patchNr] = imageRect
             self.tileRects[patchNr] = patchRect
 
-    def boundingRectF(self):
+    def boundingRectF(self) -> QRectF:
         if self.tileRectFs:
             p = self.tileRectFs[-1]
             br = QRectF(0, 0, p.x() + p.width(), p.y() + p.height())

--- a/volumina/widgets/multiStepProgressDialog.py
+++ b/volumina/widgets/multiStepProgressDialog.py
@@ -72,7 +72,7 @@ class MultiStepProgressDialog(QDialog):
 
         self.overallProgress.setValue(self._currentStep)
 
-    def setStepProgress(self, x):
+    def setStepProgress(self, x: int):
         oldx = self.currentStepProgress.value()
         self.time2 = time.time()
         self.currentStepProgress.setValue(x)

--- a/volumina/widgets/wysiwygExportOptionsDlg.py
+++ b/volumina/widgets/wysiwygExportOptionsDlg.py
@@ -139,11 +139,12 @@ class WysiwygExportOptionsDlg(QDialog):
         start = [None] * len(self.shape)
         stop = [None] * len(self.shape)
         pos5d = self.view.scene()._posModel.slicingPos5D
-        rect = self.view.viewportRect()
+        rect = self.view.viewportRect().toRect()
         for i in range(len(self.shape)):
             if self.shape[i] > 1:
                 start[i] = pos5d[i]
                 stop[i] = pos5d[i] + 1
+
         start[self.sliceAxes[0]] = rect.left()
         stop[self.sliceAxes[0]] = rect.left() + rect.width()
         start[self.sliceAxes[1]] = rect.top()
@@ -393,7 +394,7 @@ class WysiwygExportHelper(MultiStepProgressDialog):
                 coords = 0
             file_names.append(self._filename(folder, pattern, fileExt, iter_coords, coords, filename_padding))
             self._saveImg(pos, rect, file_names[-1])
-            self.setStepProgress(100 * i / num_steps)
+            self.setStepProgress(int(100 * i / num_steps))
             yield
         self.setStepProgress(100)
         self.finishStep()
@@ -419,7 +420,7 @@ class WysiwygExportHelper(MultiStepProgressDialog):
                 folder, stack_pattern, fileExt, iter_coords, [t] + [0] * (len(iter_axes) - 1), filename_padding
             )
             self.combine_stack(stack_name, *chunk)
-            self.setStepProgress(100 * t / tsteps)
+            self.setStepProgress(int(100 * t / tsteps))
             yield
 
         self.setStepProgress(100)


### PR DESCRIPTION
Screenshot functionality currently is broken in ilastik 1.4.2 betas. This PR fixes it.

Summary:
* newer version combinations of qt/python require tighter types -> casting to int to fix exceptions on opening the dialog, and running the export
* also finally hiding the cursor because I was annoyed
* removed "drawing `mode`" concept from `CrossHairCursor` as it is not used and I don't see a use for it.
* Added some tests after seeing coverage report ;)

fixes: https://github.com/ilastik/volumina/issues/236