### PR TITLE
Minor space savings for export dialog (~10 percent) and fixed subregions sizing, especially for win

### DIFF
--- a/volumina/widgets/dataExportOptionsDlg.py
+++ b/volumina/widgets/dataExportOptionsDlg.py
@@ -119,6 +119,7 @@ class DataExportOptionsDlg(QDialog):
         assert _has_lazyflow, "This widget requires lazyflow."
         super(DataExportOptionsDlg, self).__init__(parent)
         uic.loadUi(os.path.splitext(__file__)[0] + ".ui", self)
+        self.setWindowFlags(self.windowFlags() & ~Qt.WindowContextHelpButtonHint)
 
         self._opDataExport = opDataExport
         assert isinstance(

--- a/volumina/widgets/dataExportOptionsDlg.py
+++ b/volumina/widgets/dataExportOptionsDlg.py
@@ -482,6 +482,19 @@ class DataExportOptionsDlg(QDialog):
 
         self.exportFileOptionsWidget.formatValidityChange.connect(set_okay_from_format_error)
         self.exportFileOptionsWidget.pathValidityChange.connect(partial(self._set_okay_condition, "file path"))
+        self.exportFileOptionsWidget.formatChange.connect(self._handle_format_change)
+
+    def _handle_format_change(self, format: str):
+        if format in ["multi-scale OME-Zarr", "single-scale OME-Zarr"]:
+            self.axisOrderCheckbox.setEnabled(False)
+            self.outputAxisOrderEdit.setEnabled(False)
+            self.axisOrderCheckbox.setToolTip("OME-Zarr axes are always tczyx ('transpose' setting above is ignored)")
+            self.outputAxisOrderEdit.setToolTip("OME-Zarr axes are always tczyx ('transpose' setting above is ignored)")
+        else:
+            self.axisOrderCheckbox.setEnabled(True)
+            self.outputAxisOrderEdit.setEnabled(True)
+            self.axisOrderCheckbox.setToolTip("")
+            self.outputAxisOrderEdit.setToolTip("")
 
 
 # **************************************************************************

--- a/volumina/widgets/dataExportOptionsDlg.py
+++ b/volumina/widgets/dataExportOptionsDlg.py
@@ -488,8 +488,8 @@ class DataExportOptionsDlg(QDialog):
         if format in ["multi-scale OME-Zarr", "single-scale OME-Zarr"]:
             self.axisOrderCheckbox.setEnabled(False)
             self.outputAxisOrderEdit.setEnabled(False)
-            self.axisOrderCheckbox.setToolTip("OME-Zarr axes are always tczyx ('transpose' setting above is ignored)")
-            self.outputAxisOrderEdit.setToolTip("OME-Zarr axes are always tczyx ('transpose' setting above is ignored)")
+            self.axisOrderCheckbox.setToolTip("OME-Zarr axes are always tczyx")
+            self.outputAxisOrderEdit.setToolTip("OME-Zarr axes are always tczyx")
         else:
             self.axisOrderCheckbox.setEnabled(True)
             self.outputAxisOrderEdit.setEnabled(True)

--- a/volumina/widgets/dataExportOptionsDlg.ui
+++ b/volumina/widgets/dataExportOptionsDlg.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox_6">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -68,60 +68,11 @@
       <item>
        <widget class="SubregionRoiWidget" name="roiWidget">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="rowCount">
-         <number>5</number>
-        </property>
-        <property name="columnCount">
-         <number>3</number>
-        </property>
-        <attribute name="verticalHeaderCascadingSectionResizes">
-         <bool>false</bool>
-        </attribute>
-        <row>
-         <property name="text">
-          <string>t</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>x</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>y</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>z</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>c</string>
-         </property>
-        </row>
-        <column>
-         <property name="text">
-          <string>range</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>[start,</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>stop)</string>
-         </property>
-        </column>
        </widget>
       </item>
       <item>
@@ -146,7 +97,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox_3">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -286,7 +237,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -425,32 +376,12 @@
    <signal>accepted()</signal>
    <receiver>Dialog</receiver>
    <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
   </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
    <receiver>Dialog</receiver>
    <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
   </connection>
  </connections>
 </ui>

--- a/volumina/widgets/hierarchicalFileExportOptionsWidget.py
+++ b/volumina/widgets/hierarchicalFileExportOptionsWidget.py
@@ -44,10 +44,6 @@ class HierarchicalFileExportOptionsWidget(QWidget):
             self.datasetLabel.setVisible(False)
             self.datasetEdit.setVisible(False)
             self.datasetEdit.setEnabled(False)
-            axisorder_label = QLabel(
-                'Axis order: OME-Zarr axes are always tczyx ("transpose" setting above is ignored)'
-            )
-            self.gridLayout.addWidget(axisorder_label, 1, 0, 1, 3)
         else:
             self.datasetEdit.textEdited.connect(lambda: self._handleTextEdited(self.datasetEdit))
 

--- a/volumina/widgets/hierarchicalFileExportOptionsWidget.ui
+++ b/volumina/widgets/hierarchicalFileExportOptionsWidget.ui
@@ -48,7 +48,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>219</height>
+       <height>20</height>
       </size>
      </property>
     </spacer>

--- a/volumina/widgets/multiformatSlotExportFileOptionsWidget.py
+++ b/volumina/widgets/multiformatSlotExportFileOptionsWidget.py
@@ -51,6 +51,7 @@ except ImportError:
 class MultiformatSlotExportFileOptionsWidget(QWidget):
     formatValidityChange = Signal(str)  # str
     pathValidityChange = Signal(bool)
+    formatChange = Signal(str)
 
     def __init__(self, parent):
         global _has_lazyflow
@@ -202,6 +203,7 @@ class MultiformatSlotExportFileOptionsWidget(QWidget):
         self.stackedWidget.setCurrentWidget(option_widget)
 
         self._handlePathValidityChange()
+        self.formatChange.emit(file_format)
 
     def _handleFormatValidChange(self, *args):
         old_err = self._selection_error_msg

--- a/volumina/widgets/multiformatSlotExportFileOptionsWidget.ui
+++ b/volumina/widgets/multiformatSlotExportFileOptionsWidget.ui
@@ -43,7 +43,7 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>463</width>
+       <width>20</width>
        <height>20</height>
       </size>
      </property>

--- a/volumina/widgets/multiformatSlotExportFileOptionsWidget.ui
+++ b/volumina/widgets/multiformatSlotExportFileOptionsWidget.ui
@@ -52,10 +52,13 @@
    <item row="1" column="0" colspan="4">
     <widget class="QStackedWidget" name="stackedWidget"/>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="2" colspan="2">
     <widget class="QLabel" name="formatErrorLabel">
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Invalid format for current export settings.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/volumina/widgets/multiscaleFileExportOptionsWidget.py
+++ b/volumina/widgets/multiscaleFileExportOptionsWidget.py
@@ -101,11 +101,10 @@ class MultiscaleFileExportOptionsWidget(QWidget):
                     interpolation_text = interpolation_to_text[interpolation_order]
                 else:
                     interpolation_text = f"Interpolation: order {str(interpolation_order)}"
-            self.scalingInterpolationLabel.setText(interpolation_text)
 
             # scales are OrderedDict[str, OrderedDict[Axiskey, int]] (multiscalesStore.Multiscales)
             scales = self._targetScalesSlot.value
-            scales_html = "<p>Scales generated:</p><ul>"
+            scales_html = f"<p>{interpolation_text}</p><p>Scales generated:</p><ul>"
             for scale_key, tagged_shape in scales.items():
                 scales_html += f"<li><b>{scale_key}</b>: "
                 for axis_key, axis_value in tagged_shape.items():

--- a/volumina/widgets/multiscaleFileExportOptionsWidget.ui
+++ b/volumina/widgets/multiscaleFileExportOptionsWidget.ui
@@ -37,13 +37,6 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QLabel" name="scalingInterpolationLabel">
-     <property name="text">
-      <string>(Interpolation: Default)</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="0" colspan="3">
     <widget class="QScrollArea">
      <property name="widgetResizable">

--- a/volumina/widgets/multiscaleFileExportOptionsWidget.ui
+++ b/volumina/widgets/multiscaleFileExportOptionsWidget.ui
@@ -37,13 +37,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="QLabel">
-     <property name="text">
-      <string>Axis order: OME-Zarr axes are always tczyx ("transpose" setting above is ignored)</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0" colspan="3">
     <widget class="QLabel" name="scalingInterpolationLabel">
      <property name="text">

--- a/volumina/widgets/slotMetaInfoDisplayWidget.ui
+++ b/volumina/widgets/slotMetaInfoDisplayWidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>

--- a/volumina/widgets/stackExportFileOptionsWidget.ui
+++ b/volumina/widgets/stackExportFileOptionsWidget.ui
@@ -43,7 +43,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>137</height>
+       <height>20</height>
       </size>
      </property>
     </spacer>

--- a/volumina/widgets/subregionRoiWidget.py
+++ b/volumina/widgets/subregionRoiWidget.py
@@ -20,8 +20,8 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 import collections
-from qtpy.QtCore import Qt, Signal, QEvent
-from qtpy.QtWidgets import QSpinBox, QTableWidget, QTableWidgetItem
+from qtpy.QtCore import Qt, Signal, QEvent, QSize
+from qtpy.QtWidgets import QApplication, QSpinBox, QTableWidget, QTableWidgetItem
 
 DEFAULT_MAX_EXTENT = 999999
 
@@ -95,6 +95,12 @@ class SubregionRoiWidget(QTableWidget):
     def roi(self):
         return self._roi
 
+    def _width(self) -> int:
+        return self.verticalHeader().width() + sum(self.columnWidth(i) for i in range(self.columnCount()))
+
+    def _height(self) -> int:
+        return self.horizontalHeader().height() + sum(self.rowHeight(i) for i in range(self.rowCount()))
+
     def initWithExtents(self, axes, shape, start, stop):
         self.setColumnCount(3)
         self.setHorizontalHeaderLabels(["range", "[start,", "stop)"])
@@ -148,6 +154,29 @@ class SubregionRoiWidget(QTableWidget):
 
         self._updateRoi()
         self.resizeColumnsToContents()
+        self.resizeRowsToContents()
+
+        self.resize(self._width(), self._height())
+        self.updateGeometry()
+
+    def sizeHint(self):
+        self.resizeColumnsToContents()
+        self.resizeRowsToContents()
+
+        width = self._width()
+        height = self._height()
+        style = QApplication.style()
+
+        if self.verticalScrollBar().isVisible():
+            width += style.pixelMetric(style.PM_ScrollBarExtent)
+
+        if self.horizontalScrollBar().isVisible():
+            height += style.pixelMetric(style.PM_ScrollBarExtent)
+
+        return QSize(width, height)
+
+    def minimumSizeHint(self):
+        return self.sizeHint()
 
     def _updateRoi(self):
         if len(self._boxes) == 0:

--- a/volumina/widgets/wysiwygExportOptionsDlg.ui
+++ b/volumina/widgets/wysiwygExportOptionsDlg.ui
@@ -38,7 +38,7 @@
       <item row="0" column="0">
        <widget class="SubregionRoiWidget" name="roiWidget">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -123,7 +123,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox_6">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -186,7 +186,7 @@
            <bool>true</bool>
           </property>
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -275,32 +275,12 @@
    <signal>accepted()</signal>
    <receiver>Dialog</receiver>
    <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
   </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
    <receiver>Dialog</receiver>
    <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
   </connection>
  </connections>
 </ui>


### PR DESCRIPTION
way to much time spend with this for a pretty minimal return - 10 percent reduced height. Although for me on windows it was the difference between being able to use the dialog at 300% and not being able to do so before. Also for windows I couldn't get the dialog to start out at its minimum size - on mac it does...

Summary:
* OME-zarr widget: removed axisorder message label in favor of disabling the axisorder checkbox, removed interpolation label in favor of adding it to the scales preview
* fixed sizing of the subregions widget - for me this went from hideous to hideous, but usable.
* word wrapping for format error message

The height went down from 2025px to 1820..

### Screenshots
All screenshots at 250%

before (with format error message blowing up the dialog):
<img width="2944" height="2025" alt="Screenshot 2026-04-27 170255" src="https://github.com/user-attachments/assets/0d3a855b-12db-4bad-94fc-301ae2492806" />

after with dialog error message

<img width="1736" height="1820" alt="Screenshot 2026-04-27 170326" src="https://github.com/user-attachments/assets/90eaa344-ff61-4017-ba42-c24e4e5d5ff4" />

after with ome-zarr multiscale selected
 
<img width="1736" height="1820" alt="Screenshot 2026-04-27 170352" src="https://github.com/user-attachments/assets/5737fb74-80a9-4c32-839b-fef0af1dc86b" />
