### PR TITLE
Add env variable to distinguish development mode, add dev env yaml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,50 @@ jobs:
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
 
+
+  test-w-dev-env:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: dev-env
+          auto-update-conda: true
+          environment-file: environment-dev.yaml
+          miniforge-version: latest
+          conda-solver: libmamba
+          conda-remove-defaults: true
+      - name: test-is-dev-mode
+        if: matrix.os != 'windows-latest'
+        shell: bash -l {0}
+        run: python -c "import sys; import os; sys.exit(0) if os.environ.get('ILASTIK_DEVELOPMENT_ENV', None) else sys.exit(42)"
+      - name: linux test
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash -l {0}
+        run: |
+          pip install -e .
+          xvfb-run --server-args="-screen 0 1024x768x24" pytest
+      - name: osx test
+        if: matrix.os == 'macos-latest'
+        shell: bash -l {0}
+        run: |
+          pip install -e .
+          pytest
+      - name: windows test
+        if: matrix.os == 'windows-latest'
+        shell: cmd /C CALL {0}
+        # auto activation of env does not seem to work on win
+        run: >-
+          pip install -e . && pytest
+
+
   test-w-conda-recipe:
     strategy:
       fail-fast: false

--- a/Readme.md
+++ b/Readme.md
@@ -1,20 +1,18 @@
-**Volumina** - Volume Slicing and Editing Library
-=============================================
+# **Volumina** - Volume Slicing and Editing Library
 
 [![build](https://github.com/ilastik/volumina/workflows/test/badge.svg)](https://github.com/ilastik/volumina/actions)
 [![deployment](https://github.com/ilastik/volumina/workflows/deploy/badge.svg)](https://github.com/ilastik/volumina/actions)
 [![black](https://github.com/ilastik/volumina/workflows/lint/badge.svg)](https://github.com/ilastik/volumina/actions)
 [![ilastik-forge-version](https://anaconda.org/ilastik-forge/volumina/badges/version.svg)](https://anaconda.org/ilastik-forge/volumina)
 
-Installing
-==========
+## Installation
 
 ```bash
 conda install -c ilastik-forge -c conda-forge volumina
 ```
 
-Using Volumina as an Image Viewer
-=================================
+## Using Volumina as an Image Viewer
+
 
 Currently, only format supported is `.npy`.
 
@@ -28,10 +26,20 @@ volumina <myimage.npy> --axistags yx
 axisorder should correspond to the data. Only `t` (time), `c` (channel), and the spacial axes `x`, `y`, `z` are valid.
 
 
-Volumina Development
-====================
+## Volumina Development
 
-Create a development environment
---------------------------------
+### Create a development environment with ilastik
 
-To set up a development environment, we currently recommend to follow Contributing Guidelines of our main repository [ilastik](https://github.com/ilastik/ilastik): [CONTRIBUTING](https://github.com/ilastik/ilastik/blob/main/CONTRIBUTING.md)
+To set up a development environment with ilastik, we currently recommend to follow Contributing Guidelines of our main repository [ilastik](https://github.com/ilastik/ilastik): [CONTRIBUTING](https://github.com/ilastik/ilastik/blob/main/CONTRIBUTING.md)
+
+
+### Create a development environment for volumina-only development
+
+```bash
+# do this once
+conda env create -n vdev --file environment-dev.yaml
+conda activate vdev
+pip install -e .
+```
+
+Tests can be run with `pytest -v`.

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -1,0 +1,25 @@
+channels:
+  - conda-forge
+dependencies:
+  - python 3.11
+  - numpy 1.*
+  - cachetools
+  - future
+  - h5py
+  - pip
+  - platformdirs
+  - pyopengl
+  - pyqt 5.15.*
+  - pyqtgraph
+  - pytest
+  - pytest-qt
+  - qimage2ndarray
+  - qtpy
+  - typing_extensions
+  - vigra
+  - xarray
+variables:
+  # Slightly different behavior for developers:
+  # volumina.is_in_development_env() checks this flag and returns True if set
+  # used in TileProvider._fetch_layer_tile
+  ILASTIK_DEVELOPMENT_ENV: "1"

--- a/volumina/__init__.py
+++ b/volumina/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 ###############################################################################
 #   volumina: volume slicing and editing library
 #
@@ -21,6 +19,8 @@ from __future__ import absolute_import
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
+from functools import lru_cache
+import os
 import sys
 import logging
 
@@ -48,6 +48,16 @@ if not has_handler(volumina_logger):
 
     volumina_logger.setLevel(logging.INFO)
     volumina_logging_handler.setLevel(logging.INFO)
+
+
+_IS_DEVELOPMENT_ENV = os.environ.get("ILASTIK_DEVELOPMENT_ENV", None)
+
+
+def is_in_development_env() -> bool:
+    if _IS_DEVELOPMENT_ENV:
+        return True
+
+    return False
 
 
 from . import api

--- a/volumina/tiling/tileprovider.py
+++ b/volumina/tiling/tileprovider.py
@@ -35,6 +35,7 @@ from volumina.pixelpipeline.imagepump import StackedImageSources
 from volumina.pixelpipeline.interface import IndeterminateRequestError
 from volumina.pixelpipeline.slicesources import StackId
 from volumina.utility import PrioritizedThreadPoolExecutor
+from volumina import is_in_development_env
 
 from .cache import TilesCache
 from .tiling import Tiling
@@ -458,8 +459,13 @@ class TileProvider(QObject):
 
                 if stack_id == self._current_stack_id and cache is self._cache:
                     self.sceneRectChanged.emit(tile_rect)
-        except BaseException:
-            raise
+        except BaseException as e:
+            if is_in_development_env():
+                raise
+            else:
+                # hide exceptions that seem to be the result of timing issues and (so far)
+                # don't seem to affect computations/results
+                logger.error(f"Error fetching tile:\n{e}", exc_info=True)
 
     def _onLayerDirty(self, dirtyImgSrc, dataRect):
         """


### PR DESCRIPTION
We used to do special releases of ilastik for stable versions where exceptions that occur during `fetch_layer_tile` would be ignored. These exceptions seem to be triggered by temporary inconsistencies in the graph and are so far transient in nature - no need to inform users about this. But in development mode we do want to see them in order to further identify and reduce such cases.

Environment setup now also sets the environment variable `ILASTIK_DEVELOPMENT_ENV`, which is used to determine if such exceptions should be only logged, or raised.

I also added a development environment.yaml so that the variable is set for development. Also added tests running in the development env.

I considered alternatives, like special releases (which we did in the past), some additional conda-package that could be added to the dev env (which would set the environment var), or .env files. But I found going the proposed route is the easiest with our current dev setup and in principle allows us also to enable this mode in installations if necessary.

Todo after this is merged:
- [x] Follow up in ilastik environment file with the same variable setting: ilastik/ilastik/pull/3212