### PR TITLE
Fix high dpi for layer stack

### DIFF
--- a/volumina/sliceSelectorHud.py
+++ b/volumina/sliceSelectorHud.py
@@ -29,7 +29,6 @@ from qtpy.QtCore import QCoreApplication, QEvent, QPointF, QSize, Qt, Signal
 from qtpy.QtGui import QBrush, QColor, QFont, QIcon, QMouseEvent, QPainter, QPainterPath, QPen, QPixmap, QTransform
 from qtpy.QtWidgets import (
     QAbstractSpinBox,
-    QApplication,
     QCheckBox,
     QFrame,
     QHBoxLayout,
@@ -42,12 +41,13 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 from volumina.utility import ShortcutManager
+from volumina.utility.gui import dpr, em, scale_pixmap, phys
 from volumina.widgets.delayedSpinBox import DelayedSpinBox
 
 SPINBOX_CSS = "QSpinBox {{ color: {0}; background-color: {1}; border:0; }}"
 SPINBOX_CSS_BOLD = "QSpinBox {{ color: {0}; font: bold; background-color: {1}; border:0; }}"
 
-# Size multipliers relative to _em(). Tune these to adjust the overall
+# Size multipliers relative to em(). Tune these to adjust the overall
 # scale of the HUD without touching any other numbers.
 BUTTON_SIZE = 1.2  # icon button width and height
 SPACING_TN = 0.1  # tiny spacing between axis label and slice selector
@@ -59,31 +59,11 @@ SLIDER_MAX = 13.0  # maximum width of the time slider (in em units)
 INDICATOR_MAX = 13.0  # maximum width of the busy indicator (in em units)
 
 
-def _em():
-    """Base UI unit.
-    Already accounts for DPI and the user's configured font size,
-    so all other sizing should be expressed as multiples of this."""
-    return QApplication.instance().fontMetrics().ascent()
-
-
-def _dpr():
-    return QApplication.instance().devicePixelRatio()
-
-
-def _phys(logical):
-    """Convert a logical pixel value to physical pixels on this device."""
-    return round(logical * _dpr())
-
-
 def _load_icon(filename, width, height):
-    dpr = _dpr()
-
     foreground = QPixmap()
     foreground.load(filename)
-    foreground.setDevicePixelRatio(dpr)
 
     pixmap = QPixmap(foreground.size())
-    pixmap.setDevicePixelRatio(dpr)
     pixmap.fill(Qt.transparent)
 
     painter = QPainter()
@@ -91,12 +71,7 @@ def _load_icon(filename, width, height):
     painter.drawPixmap(QPointF(0, 0), foreground)
     painter.end()
 
-    pixmap = pixmap.scaled(
-        QSize(_phys(width), _phys(height)),
-        Qt.KeepAspectRatio,
-        Qt.SmoothTransformation,
-    )
-    pixmap.setDevicePixelRatio(dpr)
+    pixmap = scale_pixmap(pixmap, QSize(phys(width), phys(height)))
     return pixmap
 
 
@@ -140,13 +115,13 @@ class LabelButtons(QLabel):
         pixmap = self.pixmap()
         if pixmap and not pixmap.isNull():
             # Center in physical pixels to avoid DPR rounding drift
-            dpr = _dpr()
+            ratio = dpr()
             pw = pixmap.width()  # physical pixels
             ph = pixmap.height()
-            ww = int(self.width() * dpr)  # widget width in physical pixels
-            wh = int(self.height() * dpr)
-            x = (ww - pw) / (2 * dpr)
-            y = (wh - ph) / (2 * dpr)
+            ww = int(self.width() * ratio)  # widget width in physical pixels
+            wh = int(self.height() * ratio)
+            x = (ww - pw) / (2 * ratio)
+            y = (wh - ph) / (2 * ratio)
             painter.drawPixmap(QPointF(x, y), pixmap)
 
         # Skip QLabel's own pixmap drawing
@@ -326,7 +301,7 @@ class ImageView2DHud(QWidget):
 
         self.layout = QHBoxLayout()
         self.setLayout(self.layout)
-        self.layout.setContentsMargins(0, int(_em() * SPACING_SM), 0, 0)
+        self.layout.setContentsMargins(0, int(em() * SPACING_SM), 0, 0)
         self.layout.setSpacing(0)
 
         self.buttons = {}
@@ -348,16 +323,16 @@ class ImageView2DHud(QWidget):
         button.clicked.connect(handler)
         setupFrameStyle(button)
         self.layout.addWidget(button)
-        self.layout.addSpacing(int(_em() * SPACING_SM))
+        self.layout.addSpacing(int(em() * SPACING_SM))
 
     def createImageView2DHud(self, axis, value, backgroundColor, foregroundColor):
         self.axis = axis
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
-        self.labelsWidth = int(_em() * BUTTON_SIZE)
-        self.labelsheight = int(_em() * BUTTON_SIZE)
+        self.labelsWidth = int(em() * BUTTON_SIZE)
+        self.labelsheight = int(em() * BUTTON_SIZE)
 
-        self.layout.addSpacing(int(_em() * SPACING_SM))
+        self.layout.addSpacing(int(em() * SPACING_SM))
 
         self.axisLabel = self.createAxisLabel()
         self.sliceSelector = SpinBoxImageView(
@@ -371,7 +346,7 @@ class ImageView2DHud(QWidget):
         leftHudLayout.setContentsMargins(0, 0, 0, 0)
         leftHudLayout.setSpacing(0)
         leftHudLayout.addWidget(self.axisLabel)
-        leftHudLayout.addSpacing(int(_em() * SPACING_TN))
+        leftHudLayout.addSpacing(int(em() * SPACING_TN))
         leftHudLayout.addLayout(self.sliceSelector)
 
         leftHudFrame = FilledFrame(backgroundColor)
@@ -380,7 +355,7 @@ class ImageView2DHud(QWidget):
         self.leftHudFrame = leftHudFrame
 
         self.layout.addWidget(leftHudFrame)
-        self.layout.addSpacing(int(_em() * SPACING_LG))
+        self.layout.addSpacing(int(em() * SPACING_LG))
 
         for name, handler in [
             ("rotate-left", self.on_rotLeftButton),
@@ -400,7 +375,7 @@ class ImageView2DHud(QWidget):
 
         self.buttons["zoomlevel"] = self.zoomLevelIndicator
         self.layout.addWidget(self.zoomLevelIndicator)
-        self.layout.addSpacing(int(_em() * SPACING_SM))
+        self.layout.addSpacing(int(em() * SPACING_SM))
 
         for name, handler in [
             ("export", self.on_exportButton),
@@ -456,9 +431,8 @@ class ImageView2DHud(QWidget):
         return axisLabel
 
     def createAxisLabelPixmap(self):
-        dpr = _dpr()
         canvas = 250
-        target = int(_em() * BUTTON_SIZE)
+        target = int(em() * BUTTON_SIZE)
         pixmap = QPixmap(canvas, canvas)
         pixmap.fill(self.backgroundColor)
         painter = QPainter()
@@ -473,12 +447,7 @@ class ImageView2DHud(QWidget):
         painter.drawPath(path)
         painter.setFont(font)
         painter.end()
-        pixmap = pixmap.scaled(
-            QSize(_phys(target), _phys(target)),
-            Qt.KeepAspectRatio,
-            Qt.SmoothTransformation,
-        )
-        pixmap.setDevicePixelRatio(dpr)
+        pixmap = scale_pixmap(pixmap, QSize(phys(target), phys(target)))
         return pixmap
 
     def setAxes(self, rotation, swapped):
@@ -487,8 +456,7 @@ class ImageView2DHud(QWidget):
 
 
 def _get_pos_widget(name, backgroundColor, foregroundColor):
-    dpr = _dpr()
-    target = int(_em() * BUTTON_SIZE)
+    target = int(em() * BUTTON_SIZE)
 
     label = QLabel()
     label.setAttribute(Qt.WA_TransparentForMouseEvents, True)
@@ -511,12 +479,7 @@ def _get_pos_widget(name, backgroundColor, foregroundColor):
     painter.drawPath(path)
     painter.setFont(font)
     painter.end()
-    pixmap = pixmap.scaled(
-        QSize(_phys(target), _phys(target)),
-        Qt.KeepAspectRatio,
-        Qt.SmoothTransformation,
-    )
-    pixmap.setDevicePixelRatio(dpr)
+    pixmap = scale_pixmap(pixmap, QSize(phys(target), phys(target)))
     label.setPixmap(pixmap)
     label.setFixedSize(target, target)
     label.setAlignment(Qt.AlignCenter)
@@ -536,7 +499,7 @@ class QuadStatusBar(QHBoxLayout):
 
     def __init__(self, parent=None):
         QHBoxLayout.__init__(self, parent)
-        self.setContentsMargins(0, int(_em() * SPACING_SM), 0, 0)
+        self.setContentsMargins(0, int(em() * SPACING_SM), 0, 0)
         self.setSpacing(0)
 
     def showXYCoordinates(self):
@@ -583,7 +546,7 @@ class QuadStatusBar(QHBoxLayout):
         self.addWidget(self.zLabel)
         self.addWidget(self.zSpinBox)
 
-        self.addSpacing(int(_em() * SPACING_MD))
+        self.addSpacing(int(em() * SPACING_MD))
 
         self.crosshairsCheckbox = QCheckBox()
         self.crosshairsCheckbox.setChecked(False)
@@ -591,10 +554,10 @@ class QuadStatusBar(QHBoxLayout):
         self.crosshairsCheckbox.setText("Crosshairs")
         self.addWidget(self.crosshairsCheckbox)
 
-        self.addSpacing(int(_em() * SPACING_MD))
+        self.addSpacing(int(em() * SPACING_MD))
 
         self.busyIndicator = QProgressBar()
-        self.busyIndicator.setMaximumWidth(int(_em() * INDICATOR_MAX))
+        self.busyIndicator.setMaximumWidth(int(em() * INDICATOR_MAX))
         self.busyIndicator.setMaximum(0)
         self.busyIndicator.setMinimum(0)
         self.busyIndicator.setVisible(False)
@@ -604,7 +567,7 @@ class QuadStatusBar(QHBoxLayout):
 
         self.addStretch()
 
-        self.addSpacing(int(_em() * SPACING_LG))
+        self.addSpacing(int(em() * SPACING_LG))
 
         self.timeSpinBox = DelayedSpinBox(750)
 
@@ -621,8 +584,8 @@ class QuadStatusBar(QHBoxLayout):
         self.timePreviousButton.clicked.connect(self._onTimePreviousButtonClicked)
 
         self.timeSlider = QSlider(Qt.Horizontal)
-        self.timeSlider.setMinimumWidth(int(_em() * SLIDER_MIN))
-        self.timeSlider.setMaximumWidth(int(_em() * SLIDER_MAX))
+        self.timeSlider.setMinimumWidth(int(em() * SLIDER_MIN))
+        self.timeSlider.setMaximumWidth(int(em() * SLIDER_MAX))
         self.setToolTipTimeSlider()
         self.addWidget(self.timeSlider)
         self.timeSlider.valueChanged.connect(self._onTimeSliderChanged)

--- a/volumina/sliceSelectorHud.py
+++ b/volumina/sliceSelectorHud.py
@@ -41,22 +41,21 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 from volumina.utility import ShortcutManager
-from volumina.utility.gui import dpr, em, scale_pixmap, phys
+from volumina.utility.gui import dpr, line_height, scale_pixmap, phys
 from volumina.widgets.delayedSpinBox import DelayedSpinBox
 
 SPINBOX_CSS = "QSpinBox {{ color: {0}; background-color: {1}; border:0; }}"
 SPINBOX_CSS_BOLD = "QSpinBox {{ color: {0}; font: bold; background-color: {1}; border:0; }}"
 
-# Size multipliers relative to em(). Tune these to adjust the overall
-# scale of the HUD without touching any other numbers.
+# Size multipliers relative to line_height().
 BUTTON_SIZE = 1.2  # icon button width and height
 SPACING_TN = 0.1  # tiny spacing between axis label and slice selector
 SPACING_SM = 0.2  # tight spacing between related elements
 SPACING_MD = 0.5  # spacing between groups
 SPACING_LG = 0.8  # spacing between major sections
-SLIDER_MIN = 0.6  # minimum width of the time slider (in em units)
-SLIDER_MAX = 13.0  # maximum width of the time slider (in em units)
-INDICATOR_MAX = 13.0  # maximum width of the busy indicator (in em units)
+SLIDER_MIN = 0.6  # minimum width of the time slider
+SLIDER_MAX = 13.0  # maximum width of the time slider
+INDICATOR_MAX = 13.0  # maximum width of the busy indicator
 
 
 def _load_icon(filename, width, height):
@@ -301,7 +300,7 @@ class ImageView2DHud(QWidget):
 
         self.layout = QHBoxLayout()
         self.setLayout(self.layout)
-        self.layout.setContentsMargins(0, int(em() * SPACING_SM), 0, 0)
+        self.layout.setContentsMargins(0, int(line_height() * SPACING_SM), 0, 0)
         self.layout.setSpacing(0)
 
         self.buttons = {}
@@ -323,16 +322,16 @@ class ImageView2DHud(QWidget):
         button.clicked.connect(handler)
         setupFrameStyle(button)
         self.layout.addWidget(button)
-        self.layout.addSpacing(int(em() * SPACING_SM))
+        self.layout.addSpacing(int(line_height() * SPACING_SM))
 
     def createImageView2DHud(self, axis, value, backgroundColor, foregroundColor):
         self.axis = axis
         self.backgroundColor = backgroundColor
         self.foregroundColor = foregroundColor
-        self.labelsWidth = int(em() * BUTTON_SIZE)
-        self.labelsheight = int(em() * BUTTON_SIZE)
+        self.labelsWidth = int(line_height() * BUTTON_SIZE)
+        self.labelsheight = int(line_height() * BUTTON_SIZE)
 
-        self.layout.addSpacing(int(em() * SPACING_SM))
+        self.layout.addSpacing(int(line_height() * SPACING_SM))
 
         self.axisLabel = self.createAxisLabel()
         self.sliceSelector = SpinBoxImageView(
@@ -346,7 +345,7 @@ class ImageView2DHud(QWidget):
         leftHudLayout.setContentsMargins(0, 0, 0, 0)
         leftHudLayout.setSpacing(0)
         leftHudLayout.addWidget(self.axisLabel)
-        leftHudLayout.addSpacing(int(em() * SPACING_TN))
+        leftHudLayout.addSpacing(int(line_height() * SPACING_TN))
         leftHudLayout.addLayout(self.sliceSelector)
 
         leftHudFrame = FilledFrame(backgroundColor)
@@ -355,7 +354,7 @@ class ImageView2DHud(QWidget):
         self.leftHudFrame = leftHudFrame
 
         self.layout.addWidget(leftHudFrame)
-        self.layout.addSpacing(int(em() * SPACING_LG))
+        self.layout.addSpacing(int(line_height() * SPACING_LG))
 
         for name, handler in [
             ("rotate-left", self.on_rotLeftButton),
@@ -375,7 +374,7 @@ class ImageView2DHud(QWidget):
 
         self.buttons["zoomlevel"] = self.zoomLevelIndicator
         self.layout.addWidget(self.zoomLevelIndicator)
-        self.layout.addSpacing(int(em() * SPACING_SM))
+        self.layout.addSpacing(int(line_height() * SPACING_SM))
 
         for name, handler in [
             ("export", self.on_exportButton),
@@ -432,7 +431,7 @@ class ImageView2DHud(QWidget):
 
     def createAxisLabelPixmap(self):
         canvas = 250
-        target = int(em() * BUTTON_SIZE)
+        target = int(line_height() * BUTTON_SIZE)
         pixmap = QPixmap(canvas, canvas)
         pixmap.fill(self.backgroundColor)
         painter = QPainter()
@@ -456,7 +455,7 @@ class ImageView2DHud(QWidget):
 
 
 def _get_pos_widget(name, backgroundColor, foregroundColor):
-    target = int(em() * BUTTON_SIZE)
+    target = int(line_height() * BUTTON_SIZE)
 
     label = QLabel()
     label.setAttribute(Qt.WA_TransparentForMouseEvents, True)
@@ -499,7 +498,7 @@ class QuadStatusBar(QHBoxLayout):
 
     def __init__(self, parent=None):
         QHBoxLayout.__init__(self, parent)
-        self.setContentsMargins(0, int(em() * SPACING_SM), 0, 0)
+        self.setContentsMargins(0, int(line_height() * SPACING_SM), 0, 0)
         self.setSpacing(0)
 
     def showXYCoordinates(self):
@@ -546,7 +545,7 @@ class QuadStatusBar(QHBoxLayout):
         self.addWidget(self.zLabel)
         self.addWidget(self.zSpinBox)
 
-        self.addSpacing(int(em() * SPACING_MD))
+        self.addSpacing(int(line_height() * SPACING_MD))
 
         self.crosshairsCheckbox = QCheckBox()
         self.crosshairsCheckbox.setChecked(False)
@@ -554,10 +553,10 @@ class QuadStatusBar(QHBoxLayout):
         self.crosshairsCheckbox.setText("Crosshairs")
         self.addWidget(self.crosshairsCheckbox)
 
-        self.addSpacing(int(em() * SPACING_MD))
+        self.addSpacing(int(line_height() * SPACING_MD))
 
         self.busyIndicator = QProgressBar()
-        self.busyIndicator.setMaximumWidth(int(em() * INDICATOR_MAX))
+        self.busyIndicator.setMaximumWidth(int(line_height() * INDICATOR_MAX))
         self.busyIndicator.setMaximum(0)
         self.busyIndicator.setMinimum(0)
         self.busyIndicator.setVisible(False)
@@ -567,7 +566,7 @@ class QuadStatusBar(QHBoxLayout):
 
         self.addStretch()
 
-        self.addSpacing(int(em() * SPACING_LG))
+        self.addSpacing(int(line_height() * SPACING_LG))
 
         self.timeSpinBox = DelayedSpinBox(750)
 
@@ -584,8 +583,8 @@ class QuadStatusBar(QHBoxLayout):
         self.timePreviousButton.clicked.connect(self._onTimePreviousButtonClicked)
 
         self.timeSlider = QSlider(Qt.Horizontal)
-        self.timeSlider.setMinimumWidth(int(em() * SLIDER_MIN))
-        self.timeSlider.setMaximumWidth(int(em() * SLIDER_MAX))
+        self.timeSlider.setMinimumWidth(int(line_height() * SLIDER_MIN))
+        self.timeSlider.setMaximumWidth(int(line_height() * SLIDER_MAX))
         self.setToolTipTimeSlider()
         self.addWidget(self.timeSlider)
         self.timeSlider.valueChanged.connect(self._onTimeSliderChanged)

--- a/volumina/utility/gui.py
+++ b/volumina/utility/gui.py
@@ -19,6 +19,8 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
+from typing import Optional, Union
+
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import QApplication
@@ -34,6 +36,11 @@ def em():
     return QApplication.instance().fontMetrics().ascent()
 
 
+def line_height():
+    """Like `em` but includes descent (slightly larger). Better for vertical spacing/layout."""
+    return QApplication.instance().fontMetrics().height()
+
+
 def phys(logical):
     """Convert a logical pixel value to physical pixels on this device.
     To be avoided, but sometimes necessary to work around Qt scaling quirks."""
@@ -47,4 +54,21 @@ def scale_pixmap(pixmap: QPixmap, size: QSize):
         Qt.SmoothTransformation,
     )
     pixmap.setDevicePixelRatio(dpr())
+    return pixmap
+
+
+def get_responsive_pixmap(*args, logical_size: Optional[Union[QSize, int]] = None):
+    """
+    Load a pixmap with sane HiDPI behavior.
+    args: as passed to QPixmap
+    logical_size: Desired displayed size in logical pixels.
+    """
+    pixmap = QPixmap(*args)
+
+    if logical_size is not None:
+        if isinstance(logical_size, int):
+            logical_size = QSize(logical_size, logical_size)
+
+        pixmap = scale_pixmap(pixmap, logical_size)
+
     return pixmap

--- a/volumina/utility/gui.py
+++ b/volumina/utility/gui.py
@@ -55,20 +55,3 @@ def scale_pixmap(pixmap: QPixmap, size: QSize):
     )
     pixmap.setDevicePixelRatio(dpr())
     return pixmap
-
-
-def get_responsive_pixmap(*args, logical_size: Optional[Union[QSize, int]] = None):
-    """
-    Load a pixmap with sane HiDPI behavior.
-    args: as passed to QPixmap
-    logical_size: Desired displayed size in logical pixels.
-    """
-    pixmap = QPixmap(*args)
-
-    if logical_size is not None:
-        if isinstance(logical_size, int):
-            logical_size = QSize(logical_size, logical_size)
-
-        pixmap = scale_pixmap(pixmap, logical_size)
-
-    return pixmap

--- a/volumina/utility/gui.py
+++ b/volumina/utility/gui.py
@@ -19,35 +19,32 @@
 # This information is also available on the ilastik web site at:
 # 		   http://ilastik.org/license/
 ###############################################################################
-from typing import Optional, Union
-
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import QApplication
 
 
-def dpr():
-    return QApplication.instance().devicePixelRatio()
-
-
-def em():
-    """DPI-aware UI sizing unit based on current font metrics, similar to CSS 'em'.
-    Preferred base unit for specifying sizes of UI elements"""
-    return QApplication.instance().fontMetrics().ascent()
-
-
-def line_height():
-    """Like `em` but includes descent (slightly larger). Better for vertical spacing/layout."""
+def line_height() -> int:
+    """
+    Physical pixels per text line at font display size on this display.
+    Similar to CSS 'em', this serves as a base unit for specifying sizes of UI elements.
+    Typically around 13 on laptop or older screens, or around 30 on 4K screens."""
     return QApplication.instance().fontMetrics().height()
 
 
-def phys(logical):
+def dpr() -> float:
+    """Device display scaling factor.
+    On Win, corresponds to display scaling setting (e.g. 150%, 200% -> 1.5, 2.0)."""
+    return QApplication.instance().devicePixelRatio()
+
+
+def phys(logical) -> int:
     """Convert a logical pixel value to physical pixels on this device.
     To be avoided, but sometimes necessary to work around Qt scaling quirks."""
     return round(logical * dpr())
 
 
-def scale_pixmap(pixmap: QPixmap, size: QSize):
+def scale_pixmap(pixmap: QPixmap, size: QSize) -> QPixmap:
     pixmap = pixmap.scaled(
         size,
         Qt.KeepAspectRatio,

--- a/volumina/utility/gui.py
+++ b/volumina/utility/gui.py
@@ -1,0 +1,50 @@
+###############################################################################
+#   volumina: volume slicing and editing library
+#
+#       Copyright (C) 2011-2026, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+# 		   http://ilastik.org/license/
+###############################################################################
+from qtpy.QtCore import Qt, QSize
+from qtpy.QtGui import QPixmap
+from qtpy.QtWidgets import QApplication
+
+
+def dpr():
+    return QApplication.instance().devicePixelRatio()
+
+
+def em():
+    """DPI-aware UI sizing unit based on current font metrics, similar to CSS 'em'.
+    Preferred base unit for specifying sizes of UI elements"""
+    return QApplication.instance().fontMetrics().ascent()
+
+
+def phys(logical):
+    """Convert a logical pixel value to physical pixels on this device.
+    To be avoided, but sometimes necessary to work around Qt scaling quirks."""
+    return round(logical * dpr())
+
+
+def scale_pixmap(pixmap: QPixmap, size: QSize):
+    pixmap = pixmap.scaled(
+        size,
+        Qt.KeepAspectRatio,
+        Qt.SmoothTransformation,
+    )
+    pixmap.setDevicePixelRatio(dpr())
+    return pixmap

--- a/volumina/view3d/overview3d.py
+++ b/volumina/view3d/overview3d.py
@@ -4,7 +4,7 @@ from qtpy.QtWidgets import QWidget
 from qtpy.QtCore import Signal, Slot, QSize
 from qtpy.uic import loadUiType
 
-from volumina.utility.gui import em
+from volumina.utility.gui import line_height
 
 
 class Overview3D(QWidget):
@@ -30,6 +30,9 @@ class Overview3D(QWidget):
         dock_status_changed: indicates that the dock button was toggled
     """
 
+    _ICON_SIZE = 1.3
+    _BUTTON_SIZE = 1.9
+
     slice_changed = Signal()
     reinitialized = Signal()  # TODO: this should not be necessary: remove
     dock_status_changed = Signal(bool)
@@ -44,8 +47,8 @@ class Overview3D(QWidget):
         cls, _ = loadUiType(join(split(__file__)[0], "ui/view3d.ui"))
         self._ui = cls()
         self._ui.setupUi(self)
-        icon_size = int(em() * 1.3)
-        button_size = int(em() * 1.9)
+        icon_size = int(line_height() * self._ICON_SIZE)
+        button_size = int(line_height() * self._BUTTON_SIZE)
         for btn in (self._ui.toggle_slice_x, self._ui.toggle_slice_y, self._ui.toggle_slice_z, self._ui.dock):
             btn.setIconSize(QSize(icon_size, icon_size))
             btn.setFixedSize(QSize(button_size, button_size))

--- a/volumina/view3d/overview3d.py
+++ b/volumina/view3d/overview3d.py
@@ -1,8 +1,10 @@
 from os.path import split, join
 
-from qtpy.QtWidgets import QWidget, QApplication
+from qtpy.QtWidgets import QWidget
 from qtpy.QtCore import Signal, Slot, QSize
 from qtpy.uic import loadUiType
+
+from volumina.utility.gui import em
 
 
 class Overview3D(QWidget):
@@ -42,9 +44,8 @@ class Overview3D(QWidget):
         cls, _ = loadUiType(join(split(__file__)[0], "ui/view3d.ui"))
         self._ui = cls()
         self._ui.setupUi(self)
-        em = QApplication.instance().fontMetrics().ascent()
-        icon_size = int(em * 1.3)
-        button_size = int(em * 1.9)
+        icon_size = int(em() * 1.3)
+        button_size = int(em() * 1.9)
         for btn in (self._ui.toggle_slice_x, self._ui.toggle_slice_y, self._ui.toggle_slice_z, self._ui.dock):
             btn.setIconSize(QSize(icon_size, icon_size))
             btn.setFixedSize(QSize(button_size, button_size))

--- a/volumina/widgets/layerwidget.py
+++ b/volumina/widgets/layerwidget.py
@@ -39,7 +39,7 @@ from qtpy.QtWidgets import (
 from volumina.layer import Layer
 from volumina.layerstack import LayerStackModel
 from volumina.utility import ShortcutManager
-from volumina.utility.gui import em, line_height
+from volumina.utility.gui import line_height
 from volumina.widgets.layercontextmenu import layercontextmenu
 
 
@@ -50,15 +50,15 @@ PREV_CHANNEL_SEQ = "Ctrl+P"
 class FractionSelectionBar(QWidget):
     fractionChanged = Signal(float)
 
-    _DEFAULT_WIDTH_EM = 8.0
-    _DEFAULT_HEIGHT_EM = 0.65
-    _MIN_HEIGHT_EM = 0.15
+    _DEFAULT_WIDTH = 8.0
+    _DEFAULT_HEIGHT = 0.65
+    _MIN_HEIGHT = 0.15
 
     def __init__(self, initial_fraction=1.0, parent=None):
         super(FractionSelectionBar, self).__init__(parent=parent)
         self._fraction = initial_fraction
         self._lmbDown = False
-        self.setFixedHeight(round(em() * self._DEFAULT_HEIGHT_EM))
+        self.setFixedHeight(round(line_height() * self._DEFAULT_HEIGHT))
 
     def fraction(self):
         return self._fraction
@@ -125,12 +125,12 @@ class FractionSelectionBar(QWidget):
 
     def sizeHint(self):
         return QSize(
-            round(em() * self._DEFAULT_WIDTH_EM),
-            round(em() * self._DEFAULT_HEIGHT_EM),
+            round(line_height() * self._DEFAULT_WIDTH),
+            round(line_height() * self._DEFAULT_HEIGHT),
         )
 
     def minimumSizeHint(self):
-        return QSize(1, max(2, round(em() * self._MIN_HEIGHT_EM)))
+        return QSize(1, max(2, round(line_height() * self._MIN_HEIGHT)))
 
     def _barWidth(self):
         return self.width() - 1
@@ -149,6 +149,8 @@ class FractionSelectionBar(QWidget):
 
 
 class ToggleEye(QToolButton):
+    _EYE_SIZE = 1.25
+
     activeChanged = Signal(bool)
 
     def __init__(self, parent=None):
@@ -160,7 +162,7 @@ class ToggleEye(QToolButton):
         self.setChecked(True)
         self.setAutoRaise(True)
         self.setToolButtonStyle(Qt.ToolButtonIconOnly)
-        icon_size = round(line_height() * 1.25)
+        icon_size = round(line_height() * self._EYE_SIZE)
         self.setIconSize(QSize(icon_size, icon_size))
         self.setStyleSheet(
             """
@@ -181,7 +183,7 @@ class ToggleEye(QToolButton):
 
 class LayerItemWidget(QWidget):
 
-    _CHANNEL_WIDTH_EM = 2
+    _CHANNEL_WIDTH = 2
 
     @property
     def layer(self):
@@ -214,7 +216,7 @@ class LayerItemWidget(QWidget):
         self.toggleEye.setToolTip("Visibility")
         self.channelSelector = QSpinBox(parent=self)
         self.channelSelector.setFrame(False)
-        channel_selector_width = round(line_height() * self._CHANNEL_WIDTH_EM)
+        channel_selector_width = round(line_height() * self._CHANNEL_WIDTH)
         self.channelSelector.setMaximumWidth(channel_selector_width)
         self.channelSelector.setAlignment(Qt.AlignRight)
         self.channelSelector.setToolTip("Channel")

--- a/volumina/widgets/layerwidget.py
+++ b/volumina/widgets/layerwidget.py
@@ -30,6 +30,7 @@ from qtpy.QtWidgets import QStyledItemDelegate, QWidget, QListView, QStyle, QLab
 from volumina.layer import Layer
 from volumina.layerstack import LayerStackModel
 from volumina.utility import ShortcutManager
+from volumina.utility.gui import em, line_height, get_responsive_pixmap
 from volumina.widgets.layercontextmenu import layercontextmenu
 
 
@@ -40,10 +41,15 @@ PREV_CHANNEL_SEQ = "Ctrl+P"
 class FractionSelectionBar(QWidget):
     fractionChanged = Signal(float)
 
+    _DEFAULT_WIDTH_EM = 8.0
+    _DEFAULT_HEIGHT_EM = 0.65
+    _MIN_HEIGHT_EM = 0.15
+
     def __init__(self, initial_fraction=1.0, parent=None):
         super(FractionSelectionBar, self).__init__(parent=parent)
         self._fraction = initial_fraction
         self._lmbDown = False
+        self.setFixedHeight(round(em() * self._DEFAULT_HEIGHT_EM))
 
     def fraction(self):
         return self._fraction
@@ -84,29 +90,38 @@ class FractionSelectionBar(QWidget):
     def paintEvent(self, ev):
         painter = QPainter(self)
 
-        # calc bar offset
-        y_offset = (self.height() - self._barHeight()) // 2
-        ## prevent negative offset
-        y_offset = 0 if y_offset < 0 else y_offset
+        # Switch to physical-pixel coordinates
+        ratio = painter.device().devicePixelRatioF()
+        painter.scale(1.0 / ratio, 1.0 / ratio)
+        w = round(self.width() * ratio)
+        h = round(self.height() * ratio)
+        border_thickness = 1
 
-        # frame around fraction indicator
-        painter.setBrush(self.palette().dark())
-        painter.save()
-        ## no fill color
-        b = painter.brush()
-        b.setStyle(Qt.NoBrush)
-        painter.setBrush(b)
-        painter.drawRect(QRect(QPoint(0, y_offset), QSize(self._barWidth(), self._barHeight())))
-        painter.restore()
+        if w <= 1 or h <= 1:
+            return
 
-        # fraction indicator
-        painter.drawRect(QRect(QPoint(0, y_offset), QSize(int(self._barWidth() * self._fraction), self._barHeight())))
+        border = self.palette().color(QPalette.Text)
+        fill = self.palette().dark().color()
+
+        painter.fillRect(0, 0, w, border_thickness, border)
+        painter.fillRect(0, h - border_thickness, w, border_thickness, border)
+        painter.fillRect(0, 0, border_thickness, h, border)
+        painter.fillRect(w - border_thickness, 0, border_thickness, h, border)
+        inner_w = max(0, w - 2 * border_thickness)
+        inner_h = max(0, h - 2 * border_thickness)
+        fill_w = int(inner_w * self._fraction)
+
+        if fill_w > 0 and inner_h > 0:
+            painter.fillRect(border_thickness, border_thickness, fill_w, inner_h, fill)
 
     def sizeHint(self):
-        return QSize(100, 10)
+        return QSize(
+            round(em() * self._DEFAULT_WIDTH_EM),
+            round(em() * self._DEFAULT_HEIGHT_EM),
+        )
 
     def minimumSizeHint(self):
-        return QSize(1, 3)
+        return QSize(1, max(2, round(em() * self._MIN_HEIGHT_EM)))
 
     def _barWidth(self):
         return self.width() - 1
@@ -127,12 +142,31 @@ class FractionSelectionBar(QWidget):
 class ToggleEye(QLabel):
     activeChanged = Signal(bool)
 
+    _ICON_EM = 1.8
+
     def __init__(self, parent=None):
         super(ToggleEye, self).__init__(parent=parent)
         self._active = True
-        self._eye_open = QPixmap(":icons/icons/stock-eye-20.png")
-        self._eye_closed = QPixmap(":icons/icons/stock-eye-20-gray.png")
+
+        icon_size = round(em() * self._ICON_EM)
+
+        self._eye_open = get_responsive_pixmap(
+            ":icons/icons/stock-eye-20.png",
+            logical_size=icon_size,
+        )
+        self._eye_closed = get_responsive_pixmap(
+            ":icons/icons/stock-eye-20-gray.png",
+            logical_size=icon_size,
+        )
         self.setPixmap(self._eye_open)
+
+        # Keep label tightly wrapped around icon
+        self.setFixedSize(
+            QSize(
+                round(icon_size * 1.35),
+                round(line_height() * 1.05),
+            )
+        )
 
     def active(self):
         return self._active
@@ -158,6 +192,10 @@ class ToggleEye(QLabel):
 
 
 class LayerItemWidget(QWidget):
+
+    _CHANNEL_WIDTH_EM = 2.5
+    _EYE_COLUMN_EM = 1.8
+
     @property
     def layer(self):
         return self._layer
@@ -178,25 +216,18 @@ class LayerItemWidget(QWidget):
         super(LayerItemWidget, self).__init__(parent=parent)
         self._layer = None
 
-        self._font = QFont(QFont().defaultFamily(), 9)
-        self._fm = QFontMetrics(self._font)
         self.bar = FractionSelectionBar(initial_fraction=0.0)
-        self.bar.setFixedHeight(10)
         self.nameLabel = QLabel(parent=self)
-        self.nameLabel.setFont(self._font)
         self.nameLabel.setText("None")
         self.opacityLabel = QLabel(parent=self)
         self.opacityLabel.setAlignment(Qt.AlignRight)
-        self.opacityLabel.setFont(self._font)
         self.opacityLabel.setText("\u03B1=%0.1f%%" % (100.0 * (self.bar.fraction())))
         self.toggleEye = ToggleEye(parent=self)
         self.toggleEye.setActive(False)
-        self.toggleEye.setFixedWidth(35)
         self.toggleEye.setToolTip("Visibility")
         self.channelSelector = QSpinBox(parent=self)
         self.channelSelector.setFrame(False)
-        self.channelSelector.setFont(self._font)
-        self.channelSelector.setMaximumWidth(35)
+        self.channelSelector.setMaximumWidth(round(em() * self._CHANNEL_WIDTH_EM))
         self.channelSelector.setAlignment(Qt.AlignRight)
         self.channelSelector.setToolTip("Channel")
         self.channelSelector.setVisible(False)
@@ -208,9 +239,17 @@ class LayerItemWidget(QWidget):
         self._layout.addWidget(self.channelSelector, 1, 0)
         self._layout.addWidget(self.bar, 1, 1, 1, 2)
 
-        self._layout.setColumnMinimumWidth(0, 35)
+        self._layout.setColumnMinimumWidth(
+            0,
+            round(em() * self._EYE_COLUMN_EM),
+        )
         self._layout.setSpacing(0)
-        self._layout.setContentsMargins(5, 2, 5, 2)
+        self._layout.setContentsMargins(
+            round(em() * 0.30),
+            round(line_height() * 0.05),
+            round(em() * 0.30),
+            round(line_height() * 0.05),
+        )
 
         self.setLayout(self._layout)
 

--- a/volumina/widgets/layerwidget.py
+++ b/volumina/widgets/layerwidget.py
@@ -142,7 +142,7 @@ class FractionSelectionBar(QWidget):
 class ToggleEye(QLabel):
     activeChanged = Signal(bool)
 
-    _ICON_EM = 1.8
+    _ICON_EM = 2.2
 
     def __init__(self, parent=None):
         super(ToggleEye, self).__init__(parent=parent)
@@ -194,7 +194,7 @@ class ToggleEye(QLabel):
 class LayerItemWidget(QWidget):
 
     _CHANNEL_WIDTH_EM = 2.5
-    _EYE_COLUMN_EM = 1.8
+    _EYE_COLUMN_EM = 2.2
 
     @property
     def layer(self):

--- a/volumina/widgets/layerwidget.py
+++ b/volumina/widgets/layerwidget.py
@@ -184,6 +184,8 @@ class ToggleEye(QToolButton):
 class LayerItemWidget(QWidget):
 
     _CHANNEL_WIDTH = 2
+    _LAYER_PADDING = 0.05
+    _LAYER_PADDING_RIGHT = 0.2
 
     @property
     def layer(self):
@@ -232,9 +234,9 @@ class LayerItemWidget(QWidget):
         self._layout.setSpacing(0)
         self._layout.setContentsMargins(
             0,
-            round(line_height() * 0.05),
-            0,
-            round(line_height() * 0.05),
+            round(line_height() * self._LAYER_PADDING),
+            round(line_height() * self._LAYER_PADDING_RIGHT),
+            round(line_height() * self._LAYER_PADDING),
         )
 
         self.setLayout(self._layout)

--- a/volumina/widgets/layerwidget.py
+++ b/volumina/widgets/layerwidget.py
@@ -1,7 +1,7 @@
 ###############################################################################
 #   volumina: volume slicing and editing library
 #
-#       Copyright (C) 2011-2014, the ilastik developers
+#       Copyright (C) 2011-2026, the ilastik developers
 #                                <team@ilastik.org>
 #
 # This program is free software; you can redistribute it and/or
@@ -22,15 +22,24 @@
 from builtins import range
 from past.utils import old_div
 import warnings
-from qtpy.QtCore import Signal, Qt, QEvent, QRect, QSize, QTimer, QPoint, QItemSelectionModel
-from qtpy.QtGui import QPainter, QFontMetrics, QFont, QPalette, QMouseEvent, QPixmap
-from qtpy.QtWidgets import QStyledItemDelegate, QWidget, QListView, QStyle, QLabel, QGridLayout, QSpinBox, QApplication
+from qtpy.QtCore import Signal, Qt, QSize, QTimer, QItemSelectionModel
+from qtpy.QtGui import QPainter, QPalette, QIcon
+from qtpy.QtWidgets import (
+    QStyledItemDelegate,
+    QWidget,
+    QListView,
+    QToolButton,
+    QLabel,
+    QGridLayout,
+    QSpinBox,
+    QApplication,
+)
 
 
 from volumina.layer import Layer
 from volumina.layerstack import LayerStackModel
 from volumina.utility import ShortcutManager
-from volumina.utility.gui import em, line_height, get_responsive_pixmap
+from volumina.utility.gui import em, line_height
 from volumina.widgets.layercontextmenu import layercontextmenu
 
 
@@ -139,62 +148,40 @@ class FractionSelectionBar(QWidget):
         return frac
 
 
-class ToggleEye(QLabel):
+class ToggleEye(QToolButton):
     activeChanged = Signal(bool)
 
-    _ICON_EM = 2.2
-
     def __init__(self, parent=None):
-        super(ToggleEye, self).__init__(parent=parent)
-        self._active = True
+        super().__init__(parent)
+        self._eye_open_icon = QIcon(":icons/icons/stock-eye-20.png")
+        self._eye_closed_icon = QIcon(":icons/icons/stock-eye-20-gray.png")
 
-        icon_size = round(em() * self._ICON_EM)
-
-        self._eye_open = get_responsive_pixmap(
-            ":icons/icons/stock-eye-20.png",
-            logical_size=icon_size,
-        )
-        self._eye_closed = get_responsive_pixmap(
-            ":icons/icons/stock-eye-20-gray.png",
-            logical_size=icon_size,
-        )
-        self.setPixmap(self._eye_open)
-
-        # Keep label tightly wrapped around icon
-        self.setFixedSize(
-            QSize(
-                round(icon_size * 1.35),
-                round(line_height() * 1.05),
-            )
+        self.setCheckable(True)
+        self.setChecked(True)
+        self.setAutoRaise(True)
+        self.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        icon_size = round(line_height() * 1.25)
+        self.setIconSize(QSize(icon_size, icon_size))
+        self.setStyleSheet(
+            """
+            QToolButton { background: transparent; padding: 1px; }
+            QToolButton:pressed { background: transparent; }
+            """
         )
 
-    def active(self):
-        return self._active
+        self.toggled.connect(self._update_icon)
+        self._update_icon(self.isChecked())
 
-    def setActive(self, b):
-        if b == self._active:
-            return
-        self._active = b
-        if b:
-            self.setPixmap(self._eye_open)
-        else:
-            self.setPixmap(self._eye_closed)
+        self.setActive = self.setChecked  # legacy compatibility
 
-    def toggle(self):
-        if self.active():
-            self.setActive(False)
-        else:
-            self.setActive(True)
-
-    def mousePressEvent(self, ev):
-        self.toggle()
-        self.activeChanged.emit(self._active)
+    def _update_icon(self, visible):
+        self.setIcon(self._eye_open_icon if visible else self._eye_closed_icon)
+        self.activeChanged.emit(visible)
 
 
 class LayerItemWidget(QWidget):
 
-    _CHANNEL_WIDTH_EM = 2.5
-    _EYE_COLUMN_EM = 2.2
+    _CHANNEL_WIDTH_EM = 2
 
     @property
     def layer(self):
@@ -227,7 +214,8 @@ class LayerItemWidget(QWidget):
         self.toggleEye.setToolTip("Visibility")
         self.channelSelector = QSpinBox(parent=self)
         self.channelSelector.setFrame(False)
-        self.channelSelector.setMaximumWidth(round(em() * self._CHANNEL_WIDTH_EM))
+        channel_selector_width = round(line_height() * self._CHANNEL_WIDTH_EM)
+        self.channelSelector.setMaximumWidth(channel_selector_width)
         self.channelSelector.setAlignment(Qt.AlignRight)
         self.channelSelector.setToolTip("Channel")
         self.channelSelector.setVisible(False)
@@ -238,16 +226,12 @@ class LayerItemWidget(QWidget):
         self._layout.addWidget(self.opacityLabel, 0, 2)
         self._layout.addWidget(self.channelSelector, 1, 0)
         self._layout.addWidget(self.bar, 1, 1, 1, 2)
-
-        self._layout.setColumnMinimumWidth(
-            0,
-            round(em() * self._EYE_COLUMN_EM),
-        )
+        self._layout.setColumnMinimumWidth(0, channel_selector_width)
         self._layout.setSpacing(0)
         self._layout.setContentsMargins(
-            round(em() * 0.30),
+            0,
             round(line_height() * 0.05),
-            round(em() * 0.30),
+            0,
             round(line_height() * 0.05),
         )
 


### PR DESCRIPTION
Didn't realise this came from volumina :)

* Screenshots show a side-by-side of 1.4.2b9 baseline (left) vs high-dpi (right).
* I'm still working on fixing the splitter in ilastik; it's wide enough to see the layer stack now but apparently I accidentally made that its max width now 😅 
* The "move layer up/down" buttons below the layer stack are from ilastik

<details>
  <summary>Before (main)</summary>

  <img width="965" height="349" alt="image" src="https://github.com/user-attachments/assets/39e2a343-33f7-4e31-a6aa-26bc19a0c87e" />
</details>


<details>
  <summary>After</summary>

  <img width="978" height="352" alt="image" src="https://github.com/user-attachments/assets/75ed7fae-1012-4581-852f-970a09362891" />
</details>