### PR TITLE
Fix black toggle-eye background on Ubuntu

### DIFF
--- a/volumina/widgets/layerwidget.py
+++ b/volumina/widgets/layerwidget.py
@@ -164,21 +164,19 @@ class ToggleEye(QToolButton):
         self.setToolButtonStyle(Qt.ToolButtonIconOnly)
         icon_size = round(line_height() * self._EYE_SIZE)
         self.setIconSize(QSize(icon_size, icon_size))
-        self.setStyleSheet(
-            """
-            QToolButton { background: transparent; padding: 1px; }
-            QToolButton:pressed { background: transparent; }
-            """
-        )
 
-        self.toggled.connect(self._update_icon)
-        self._update_icon(self.isChecked())
+        self.toggled.connect(self.activeChanged)
 
         self.setActive = self.setChecked  # legacy compatibility
 
-    def _update_icon(self, visible):
-        self.setIcon(self._eye_open_icon if visible else self._eye_closed_icon)
-        self.activeChanged.emit(visible)
+    def paintEvent(self, event):
+        # Ubuntu ignored styleSheet with `background: transparent`, so custom paintEvent it is.
+        painter = QPainter(self)
+        icon = self._eye_open_icon if self.isChecked() else self._eye_closed_icon
+        pixmap = icon.pixmap(self.iconSize())
+        x = (self.width() - pixmap.width()) // 2
+        y = (self.height() - pixmap.height()) // 2
+        painter.drawPixmap(x, y, pixmap)
 
 
 class LayerItemWidget(QWidget):


### PR DESCRIPTION
Black button shows up for visible layers on Ubuntu (second layer in the examples)

Current: 
<img width="124" height="349" alt="image" src="https://github.com/user-attachments/assets/68b1aa4f-e21a-463c-b524-7c7762b3449f" />

PR:
<img width="106" height="328" alt="image" src="https://github.com/user-attachments/assets/db69ea66-f0f7-4b9e-bf7b-961ce16834a3" />

On Win the look is unchanged:
<img width="108" height="207" alt="image" src="https://github.com/user-attachments/assets/6f35df78-409c-4f94-ae6b-eed0b2d9ee8a" />
