### PR TITLE
Export dialog: Adapt multiscale preview to clearscale

### DIFF
--- a/volumina/widgets/multiscaleFileExportOptionsWidget.py
+++ b/volumina/widgets/multiscaleFileExportOptionsWidget.py
@@ -105,9 +105,9 @@ class MultiscaleFileExportOptionsWidget(QWidget):
             # scales are OrderedDict[str, OrderedDict[Axiskey, int]] (multiscalesStore.Multiscales)
             scales = self._targetScalesSlot.value
             scales_html = f"<p>{interpolation_text}</p><p>Scales generated:</p><ul>"
-            for scale_key, tagged_shape in scales.items():
+            for scale_key, scale in scales.items():
                 scales_html += f"<li><b>{scale_key}</b>: "
-                for axis_key, axis_value in tagged_shape.items():
+                for axis_key, axis_value in scale.shape.items():
                     scales_html += f"{axis_key}: {axis_value}, "
                 scales_html = scales_html[:-2] + "</li>"
             scales_html += "</ul>"


### PR DESCRIPTION
Accompanying https://github.com/ilastik/ilastik/pull/3232

Made me wonder whether maybe we move this snippet into lazyflow... Some helper like `lazyflow.operators.opResize.get_scale_items_html()`